### PR TITLE
Feature/20348 leder

### DIFF
--- a/mora/service/association.py
+++ b/mora/service/association.py
@@ -32,7 +32,7 @@ def create_association(employee_uuid, req):
     org_unit_uuid = req.get(keys.ORG_UNIT).get('uuid')
     org_uuid = c.organisationenhed.get(
         org_unit_uuid)['relationer']['tilhoerer'][0]['uuid']
-    job_title_uuid = req.get(keys.JOB_FUNCTION).get('uuid') if req.get(
+    job_function_uuid = req.get(keys.JOB_FUNCTION).get('uuid') if req.get(
         keys.JOB_FUNCTION) else None
     association_type_uuid = req.get(keys.ASSOCIATION_TYPE).get('uuid')
     # location_uuid = req.get(LOCATION).get('uuid')
@@ -50,7 +50,7 @@ def create_association(employee_uuid, req):
         tilknyttedeorganisationer=[org_uuid],
         tilknyttedeenheder=[org_unit_uuid],
         funktionstype=association_type_uuid,
-        opgaver=[job_title_uuid] if job_title_uuid else None,
+        opgaver=[{'uuid': job_function_uuid}] if job_function_uuid else None
         # adresser=[location_uuid]
     )
 

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -89,13 +89,9 @@ def inactivate_old_interval(old_from: str, old_to: str, new_from: str,
     return payload
 
 
-def set_object_value(obj: dict, path: tuple, val: Union[dict, List[dict]],
-                     overwrite: bool = False):
+def set_object_value(obj: dict, path: tuple, val: List[dict]):
     path_list = list(path)
     obj_copy = copy.deepcopy(obj)
-
-    if val is not list:
-        val = list(val)
 
     current_value = obj_copy
     while path_list:
@@ -103,7 +99,7 @@ def set_object_value(obj: dict, path: tuple, val: Union[dict, List[dict]],
         if path_list:
             current_value = current_value.setdefault(key, {})
         else:
-            if overwrite or not current_value.get(key):
+            if not current_value.get(key):
                 current_value[key] = val
             else:
                 current_value[key].extend(val)

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -10,7 +10,7 @@ import copy
 import datetime
 import functools
 from enum import Enum
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Union
 
 import flask
 import iso8601
@@ -89,10 +89,13 @@ def inactivate_old_interval(old_from: str, old_to: str, new_from: str,
     return payload
 
 
-def set_object_value(obj: dict, path: tuple, vals: List[dict],
+def set_object_value(obj: dict, path: tuple, val: Union[dict, List[dict]],
                      overwrite: bool = False):
     path_list = list(path)
     obj_copy = copy.deepcopy(obj)
+
+    if val is not list:
+        val = list(val)
 
     current_value = obj_copy
     while path_list:
@@ -101,9 +104,9 @@ def set_object_value(obj: dict, path: tuple, vals: List[dict],
             current_value = current_value.setdefault(key, {})
         else:
             if overwrite or not current_value.get(key):
-                current_value[key] = vals
+                current_value[key] = val
             else:
-                current_value[key].extend(vals)
+                current_value[key].extend(val)
 
     return obj_copy
 
@@ -310,7 +313,7 @@ def create_organisationsfunktion_payload(
     tilknyttedeorganisationer: List[str],
     tilknyttedeenheder: List[str] = None,
     funktionstype: str = None,
-    opgaver: List[str] = None,
+    opgaver: List[dict] = None,
     adresser: List[str] = None
 ) -> dict:
     virkning = _create_virkning(valid_from, valid_to)
@@ -357,9 +360,7 @@ def create_organisationsfunktion_payload(
         }]
 
     if opgaver:
-        org_funk['relationer']['opgaver'] = [{
-            'uuid': uuid
-        } for uuid in opgaver]
+        org_funk['relationer']['opgaver'] = opgaver
 
     if adresser:
         org_funk['relationer']['adresser'] = [{

--- a/mora/service/employee.py
+++ b/mora/service/employee.py
@@ -19,6 +19,7 @@ import flask
 
 from mora import lora
 from . import association, common, engagement, itsystem, org, keys, leave, role
+from . import manager
 from .. import util
 from ..converters import writing
 
@@ -268,7 +269,38 @@ def create_employee(employee_uuid):
         }
       ]
 
-    **Leader**:
+    **Manager**:
+
+    :<jsonarr string type: **"manager"**
+    :<jsonarr string org_unit: The associated org unit
+    :<jsonarr string manager_type: The manager type
+    :<jsonarr string responsibility: The manager responsibility
+    :<jsonarr string manager_level: The manager level
+    :<jsonarr object validity: The validities of the created object.
+
+    .. sourcecode:: json
+
+      [
+        {
+          "type": "manager",
+          "org_unit": {
+            "uuid": "a30f5f68-9c0d-44e9-afc9-04e58f52dfec"
+          },
+          "manager_type": {
+            "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
+          },
+          "responsibility": {
+            "uuid": "e6b24f90-b056-433b-ad65-e6ab95d25826"
+          },
+          "manager_level": {
+            "uuid": "f17f2d60-9750-4577-a367-8a5f065b63fa"
+          },
+          "validity": {
+              "from": "2016-01-01T00:00:00+00:00",
+              "to": "2018-01-01T00:00:00+00:00"
+          }
+        }
+      ]
 
     **Leave**:
 
@@ -299,7 +331,7 @@ def create_employee(employee_uuid):
         'it': itsystem.create_system,
         'role': role.create_role,
         'contact': writing.create_contact,
-        # 'leader': create_leader,
+        'manager': manager.create_manager,
         'leave': leave.create_leave,
     }
 
@@ -550,6 +582,65 @@ def edit_employee(employee_uuid):
           }
         }
       ]
+
+    **Manager**:
+
+    :param employee_uuid: The UUID of the employee.
+
+    :<json string type: **"manager"**
+    :<json string uuid: The UUID of the manager,
+    :<json object original: An **optional** object containing the original
+        state of the leave to be overwritten. If supplied, the change will
+        modify the existing registration on the leave object. Detailed below.
+    :<json object data: An object containing the changes to be made to the
+        leave. Detailed below.
+
+    The **original** and **data** objects follow the same structure.
+    Every field in **original** is required, whereas **data** only needs
+    to contain the fields that need to change along with the validity dates.
+
+    :<jsonarr string manager_type: The manager type
+    :<jsonarr string org_unit: The associated org unit
+    :<jsonarr string manager_type: The manager type
+    :<jsonarr string responsibility: The manager responsibility
+    :<jsonarr string manager_level: The manager level
+    :<jsonarr object validity: The validities of the changes.
+
+    .. sourcecode:: json
+
+      [
+        {
+          "type": "leave",
+          "uuid": "de9e7513-1934-481f-b8c8-45336387e9cb",
+          "original": {
+              "org_unit": {
+                "uuid": "a30f5f68-9c0d-44e9-afc9-04e58f52dfec"
+              },
+              "manager_type": {
+                "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
+              },
+              "responsibility": {
+                "uuid": "e6b24f90-b056-433b-ad65-e6ab95d25826"
+              },
+              "manager_level": {
+                "uuid": "f17f2d60-9750-4577-a367-8a5f065b63fa"
+              },
+              "validity": {
+                  "from": "2016-01-01T00:00:00+00:00",
+                  "to": "2018-01-01T00:00:00+00:00"
+              }
+          },
+          "data": {
+            "validity": {
+                "from": "2016-01-01T00:00:00+00:00",
+                "to": "2019-01-01T00:00:00+00:00"
+            },
+            "manager_type": {
+              "uuid": "eee27f47-8355-4ae2-b223-0ee0fdad81be"
+            }
+          }
+        }
+      ]
     """
 
     handlers = {
@@ -558,8 +649,8 @@ def edit_employee(employee_uuid):
         'role': role.edit_role,
         'it': itsystem.edit_system,
         'leave': leave.edit_leave,
+        'manager': manager.edit_manager,
         # 'contact': edit_contact,
-        # 'leader': edit_leader,
     }
 
     reqs = flask.request.get_json()
@@ -610,6 +701,7 @@ def terminate_employee(employee_uuid):
         keys.ASSOCIATION_KEY,
         keys.ROLE_KEY,
         keys.LEAVE_KEY,
+        keys.MANAGER_KEY
     )
     for key in types:
         for obj in c.organisationfunktion.get_all(

--- a/mora/service/employee.py
+++ b/mora/service/employee.py
@@ -610,7 +610,7 @@ def edit_employee(employee_uuid):
 
       [
         {
-          "type": "leave",
+          "type": "manager",
           "uuid": "de9e7513-1934-481f-b8c8-45336387e9cb",
           "original": {
               "org_unit": {

--- a/mora/service/engagement.py
+++ b/mora/service/engagement.py
@@ -229,6 +229,20 @@ def get_engagement(type, id, function):
         except (KeyError, IndexError):
             return None
 
+    def get_responsibility(effect):
+        try:
+            return list(filter(mapping.RESPONSIBILITY_FIELD.filter_fn,
+                               effect['relationer']['opgaver']))[-1]['uuid']
+        except (KeyError, IndexError):
+            return None
+
+    def get_manager_level(effect):
+        try:
+            return list(filter(mapping.MANAGER_LEVEL_FIELD.filter_fn,
+                               effect['relationer']['opgaver']))[-1]['uuid']
+        except (KeyError, IndexError):
+            return None
+
     def convert_engagement(funcid, effect):
         return {
             "uuid": funcid,
@@ -266,6 +280,17 @@ def get_engagement(type, id, function):
             keys.LEAVE_TYPE: class_cache[get_type_id(effect)],
         }
 
+    def convert_manager(funcid, effect):
+        return {
+            "uuid": funcid,
+
+            keys.PERSON: user_cache[get_employee_id(effect)],
+            keys.ORG_UNIT: unit_cache[get_unit_id(effect)],
+            keys.RESPONSIBILITY: class_cache[get_responsibility(effect)],
+            keys.MANAGER_LEVEL: class_cache[get_manager_level(effect)],
+            keys.MANAGER_TYPE: class_cache[get_type_id(effect)],
+        }
+
     def add_validity(start, end, func):
         func[keys.VALIDITY] = {
             keys.FROM: util.to_iso_time(start),
@@ -273,21 +298,25 @@ def get_engagement(type, id, function):
         }
         return func
 
+    def get_classes(effect):
+        rels = effect['relationer']
+        return [obj['uuid'] for obj in itertools.chain(
+            rels.get('opgaver', []),
+            rels.get('organisatoriskfunktionstype', [])
+        )]
+
     converters = {
         'engagement': convert_engagement,
         'association': convert_association,
         'role': convert_role,
         'leave': convert_leave,
+        'manager': convert_manager,
     }
 
     class_cache = {
         classid: classid and facet.get_one_class(c, classid, classobj)
         for classid, classobj in c.klasse.get_all(
-            uuid=itertools.chain(
-                map(get_title_id, functions.values()),
-                map(get_type_id, functions.values()),
-            )
-        )
+            uuid=itertools.chain(*map(get_classes, functions.values())))
     }
 
     user_cache = {
@@ -373,7 +402,7 @@ def create_engagement(employee_uuid, req):
         tilknyttedeorganisationer=[org_uuid],
         tilknyttedeenheder=[org_unit_uuid],
         funktionstype=engagement_type_uuid,
-        opgaver=[job_function_uuid]
+        opgaver=[{'uuid': job_function_uuid}]
     )
 
     c.organisationfunktion.create(engagement)

--- a/mora/service/engagement.py
+++ b/mora/service/engagement.py
@@ -43,14 +43,15 @@ def list_details(type, id):
         "association": false,
         "engagement": true,
         "role": false,
-        "leave": true
+        "leave": true,
+        "manager": false
       }
 
-    The value above informs you that 'association', 'engagement', 'role' and
-    'leave' are valid for this entry, and that no entry exists at any time
-    for 'association' and 'role', whereas 'engagement' and 'leave' have at
-    least one entry either in the past, present or future.
-
+    The value above informs you that 'association', 'engagement', 'role',
+    'leave' and 'manager' are valid for this entry, and that no entry exists
+    at any time for 'association', 'role' and 'manager', whereas
+    'engagement' and 'leave' have at least one entry either in the past,
+    present or future.
     '''
     c = common.get_connector()
 
@@ -300,7 +301,7 @@ def get_engagement(type, id, function):
 
     def get_classes(effect):
         rels = effect['relationer']
-        return [obj['uuid'] for obj in itertools.chain(
+        return [obj.get('uuid') for obj in itertools.chain(
             rels.get('opgaver', []),
             rels.get('organisatoriskfunktionstype', [])
         )]

--- a/mora/service/engagement.py
+++ b/mora/service/engagement.py
@@ -47,11 +47,8 @@ def list_details(type, id):
         "manager": false
       }
 
-    The value above informs you that 'association', 'engagement', 'role',
-    'leave' and 'manager' are valid for this entry, and that no entry exists
-    at any time for 'association', 'role' and 'manager', whereas
-    'engagement' and 'leave' have at least one entry either in the past,
-    present or future.
+    The value above informs you that at least one entry exists for each of
+    'engagement' and 'leave' either in the past, present or future.
     '''
     c = common.get_connector()
 

--- a/mora/service/keys.py
+++ b/mora/service/keys.py
@@ -41,6 +41,12 @@ ROLE_TYPE = 'role_type'
 LEAVE_KEY = 'Orlov'
 LEAVE_TYPE = 'leave_type'
 
+# Manager
+MANAGER_KEY = 'Leder'
+MANAGER_TYPE = 'manager_type'
+MANAGER_LEVEL = 'manager_level'
+RESPONSIBILITY = 'responsibility'
+
 # Org unit
 ORG_UNIT_TYPE = 'org_unit_type'
 
@@ -49,4 +55,5 @@ FUNCTION_KEYS = {
     'association': ASSOCIATION_KEY,
     'role': ROLE_KEY,
     'leave': LEAVE_KEY,
+    'manager': MANAGER_KEY,
 }

--- a/mora/service/manager.py
+++ b/mora/service/manager.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+"""
+Manager
+------
+
+This section describes how to interact with employee manager roles.
+
+"""
+import uuid
+
+import flask
+
+from mora import lora
+from . import keys
+from . import mapping
+from . import common
+
+blueprint = flask.Blueprint('manager', __name__, static_url_path='',
+                            url_prefix='/service')
+
+
+def create_manager(employee_uuid, req):
+    # TODO: Validation
+    c = lora.Connector()
+
+    org_unit_uuid = req.get(keys.ORG_UNIT).get('uuid')
+    org_uuid = c.organisationenhed.get(
+        org_unit_uuid)['relationer']['tilhoerer'][0]['uuid']
+    manager_type_uuid = req.get(keys.MANAGER_TYPE).get('uuid')
+    responsibility_uuid = req.get(keys.RESPONSIBILITY).get('uuid')
+    manager_level_uuid = req.get(keys.MANAGER_LEVEL).get('uuid')
+
+    opgaver = [
+        {
+            'objekttype': 'lederansvar',
+            'uuid': responsibility_uuid
+        },
+        {
+            'objekttype': 'lederniveau',
+            'uuid': manager_level_uuid
+        },
+    ]
+
+    # TODO: Figure out what to do with this
+    # location_uuid = req.get(keys.LOCATION).get('uuid')
+    valid_from = common.get_valid_from(req)
+    valid_to = common.get_valid_to(req)
+
+    bvn = str(uuid.uuid4())
+
+    manager = common.create_organisationsfunktion_payload(
+        funktionsnavn=keys.MANAGER_KEY,
+        valid_from=valid_from,
+        valid_to=valid_to,
+        brugervendtnoegle=bvn,
+        tilknyttedebrugere=[employee_uuid],
+        tilknyttedeorganisationer=[org_uuid],
+        tilknyttedeenheder=[org_unit_uuid],
+        funktionstype=manager_type_uuid,
+        opgaver=opgaver,
+        # adresser=[location_uuid]
+    )
+
+    c.organisationfunktion.create(manager)
+
+
+def edit_manager(employee_uuid, req):
+    manager_uuid = req.get('uuid')
+    # Get the current org-funktion which the user wants to change
+    c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+    original = c.organisationfunktion.get(uuid=manager_uuid)
+
+    data = req.get('data')
+    new_from = common.get_valid_from(data)
+    new_to = common.get_valid_to(data)
+
+    payload = dict()
+    payload['note'] = 'Rediger leder'
+
+    original_data = req.get('original')
+    if original_data:
+        # We are performing an update
+        old_from = common.get_valid_from(original_data)
+        old_to = common.get_valid_to(original_data)
+        payload = common.inactivate_old_interval(
+            old_from, old_to, new_from, new_to, payload,
+            ('tilstande', 'organisationfunktiongyldighed')
+        )
+
+    update_fields = list()
+
+    # Always update gyldighed
+    update_fields.append((
+        mapping.ORG_FUNK_GYLDIGHED_FIELD,
+        {'gyldighed': "Aktiv"}
+    ))
+
+    if keys.MANAGER_TYPE in data.keys():
+        update_fields.append((
+            mapping.ORG_FUNK_TYPE_FIELD,
+            {'uuid': data.get(keys.MANAGER_TYPE).get('uuid')},
+        ))
+
+    if keys.ORG_UNIT in data.keys():
+        update_fields.append((
+            mapping.ORG_UNIT_FIELD,
+            {'uuid': data.get(keys.ORG_UNIT).get('uuid')},
+        ))
+
+    if keys.RESPONSIBILITY in data.keys():
+        update_fields.append((
+            mapping.RESPONSIBILITY_FIELD,
+            {
+                'objekttype': 'lederansvar',
+                'uuid': data.get(keys.RESPONSIBILITY).get('uuid')
+            },
+        ))
+    if keys.MANAGER_LEVEL in data.keys():
+        update_fields.append((
+            mapping.MANAGER_LEVEL_FIELD,
+            {
+                'objekttype': 'lederniveau',
+                'uuid': data.get(keys.MANAGER_LEVEL).get('uuid')
+            },
+        ))
+
+    payload = common.update_payload(new_from, new_to, update_fields, original,
+                                    payload)
+
+    bounds_fields = list(
+        mapping.MANAGER_FIELDS.difference({x[0] for x in update_fields}))
+    payload = common.ensure_bounds(new_from, new_to, bounds_fields, original,
+                                   payload)
+
+    c.organisationfunktion.update(payload, manager_uuid)

--- a/mora/service/mapping.py
+++ b/mora/service/mapping.py
@@ -56,6 +56,24 @@ ADDRESSES_FIELD = FieldTuple(
     filter_fn=lambda x: True
 )
 
+MANAGER_TYPE_FIELD = FieldTuple(
+    path=('relationer', 'organisatoriskfunktionstype'),
+    type=FieldTypes.ZERO_TO_ONE,
+    filter_fn=lambda x: True
+)
+
+RESPONSIBILITY_FIELD = FieldTuple(
+    path=('relationer', 'opgaver'),
+    type=FieldTypes.ADAPTED_ZERO_TO_MANY,
+    filter_fn=lambda x: x['objekttype'] == 'lederansvar'
+)
+
+MANAGER_LEVEL_FIELD = FieldTuple(
+    path=('relationer', 'opgaver'),
+    type=FieldTypes.ADAPTED_ZERO_TO_MANY,
+    filter_fn=lambda x: x['objekttype'] == 'lederniveau'
+)
+
 ENGAGEMENT_FIELDS = {
     ORG_FUNK_EGENSKABER_FIELD,
     ORG_FUNK_GYLDIGHED_FIELD,
@@ -92,6 +110,17 @@ LEAVE_FIELDS = {
     ORG_FUNK_TYPE_FIELD,
     ORG_FIELD,
     USER_FIELD,
+}
+
+MANAGER_FIELDS = {
+    ORG_FUNK_EGENSKABER_FIELD,
+    ORG_FUNK_GYLDIGHED_FIELD,
+    ORG_FUNK_TYPE_FIELD,
+    ORG_UNIT_FIELD,
+    ORG_FIELD,
+    USER_FIELD,
+    RESPONSIBILITY_FIELD,
+    MANAGER_LEVEL_FIELD,
 }
 
 ITSYSTEMS_FIELD = FieldTuple(

--- a/mora/service/org.py
+++ b/mora/service/org.py
@@ -21,6 +21,7 @@ import operator
 import flask
 import werkzeug
 
+from . import common, keys
 from .. import util
 from . import common
 from . import keys
@@ -142,7 +143,8 @@ def get_organisation(orgid):
     # 0.8s -> 12.3s for 28k users and 33k functions
     # https://redmine.magenta-aps.dk/issues/21273
     users = c.bruger(tilhoerer=orgid)
-    functions = c.organisationfunktion(tilknyttedeorganisationer=orgid)
+    functions = c.organisationfunktion(tilknyttedeorganisationer=orgid,
+                                       funktionsnavn=keys.ENGAGEMENT_KEY)
 
     return flask.jsonify({
         'name': attrs['organisationsnavn'],

--- a/mora/service/org.py
+++ b/mora/service/org.py
@@ -121,7 +121,11 @@ def get_organisation(orgid):
         "person_count": 2,
         "child_count": 1,
         "unit_count": 6,
-        "employment_count": 1
+        "employment_count": 1,
+        'association_count': 1,
+        'leave_count': 1,
+        'role_count': 1,
+        'manager_count': 1
       }
 
     '''
@@ -143,8 +147,16 @@ def get_organisation(orgid):
     # 0.8s -> 12.3s for 28k users and 33k functions
     # https://redmine.magenta-aps.dk/issues/21273
     users = c.bruger(tilhoerer=orgid)
-    functions = c.organisationfunktion(tilknyttedeorganisationer=orgid,
-                                       funktionsnavn=keys.ENGAGEMENT_KEY)
+    engagements = c.organisationfunktion(tilknyttedeorganisationer=orgid,
+                                         funktionsnavn=keys.ENGAGEMENT_KEY)
+    associations = c.organisationfunktion(tilknyttedeorganisationer=orgid,
+                                          funktionsnavn=keys.ASSOCIATION_KEY)
+    leaves = c.organisationfunktion(tilknyttedeorganisationer=orgid,
+                                    funktionsnavn=keys.LEAVE_KEY)
+    roles = c.organisationfunktion(tilknyttedeorganisationer=orgid,
+                                   funktionsnavn=keys.ROLE_KEY)
+    managers = c.organisationfunktion(tilknyttedeorganisationer=orgid,
+                                      funktionsnavn=keys.MANAGER_KEY)
 
     return flask.jsonify({
         'name': attrs['organisationsnavn'],
@@ -153,7 +165,11 @@ def get_organisation(orgid):
         'child_count': len(children),
         'unit_count': len(units),
         'person_count': len(users),
-        'employment_count': len(functions),
+        'employment_count': len(engagements),
+        'association_count': len(associations),
+        'leave_count': len(leaves),
+        'role_count': len(roles),
+        'manager_count': len(managers),
     })
 
 

--- a/tests/fixtures/create_organisationfunktion_leder.json
+++ b/tests/fixtures/create_organisationfunktion_leder.json
@@ -1,0 +1,82 @@
+{
+  "attributter": {
+    "organisationfunktionegenskaber": [
+      {
+        "brugervendtnoegle": "be736ee5-5c44-4ed9-b4a4-15ffa19e2848",
+        "funktionsnavn": "Leder",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ]
+  },
+  "note": "Automatisk indl\u00e6sning",
+  "relationer": {
+    "organisatoriskfunktionstype": [
+      {
+        "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ],
+    "opgaver": [
+      {
+        "objekttype": "lederansvar",
+        "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      },
+      {
+        "objekttype": "lederniveau",
+        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ],
+    "tilknyttedebrugere": [
+      {
+        "uuid": "53181ed2-f1de-4c4a-a8fd-ab358c2c454a",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ],
+    "tilknyttedeenheder": [
+      {
+        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ],
+    "tilknyttedeorganisationer": [
+      {
+        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ]
+  },
+  "tilstande": {
+    "organisationfunktiongyldighed": [
+      {
+        "gyldighed": "Aktiv",
+        "virkning": {
+          "from": "2017-01-01 00:00:00+01:00",
+          "to": "infinity"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_create_orgfunk.py
+++ b/tests/test_create_orgfunk.py
@@ -112,8 +112,14 @@ class TestCreateOrgFunk(unittest.TestCase):
         tilknyttedeenheder = ["a30f5f68-9c0d-44e9-afc9-04e58f52dfec",
                               "3f2e320e-d265-4480-a4f6-b92e40cf91b3"]
         funktionstype = "62ec821f-4179-4758-bfdf-134529d186e9"
-        opgaver = ["3ef81e52-0deb-487d-9d0e-a69bbe0277d8",
-                   "8017363b-e836-41c1-8511-2287d8fbc8a2"]
+        opgaver = [
+            {
+                "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8",
+            },
+            {
+                "uuid": "8017363b-e836-41c1-8511-2287d8fbc8a2"
+            },
+        ]
 
         self.assertDictEqual(
             create_organisationsfunktion_payload(

--- a/tests/test_integration_importing.py
+++ b/tests/test_integration_importing.py
@@ -1411,19 +1411,19 @@ class IntegrationTests(util.LoRATestCase):
             self.assertRequestResponse(
                 '/service/e/34705881-8af9-4254-ac3f-31738eae0be8/details/',
                 {'association': False, 'engagement': True, 'it': False,
-                 'leave': False, 'role': False},
+                 'leave': False, 'role': False, 'manager': False},
             )
 
             self.assertRequestResponse(
                 '/service/e/1ce40e25-6238-4202-9e93-526b348ec745/details/',
                 {'association': True, 'engagement': True, 'it': False,
-                 'leave': True, 'role': True},
+                 'leave': True, 'role': True, 'manager': False},
             )
 
             self.assertRequestResponse(
                 '/service/ou/9f42976b-93be-4e0b-9a25-0dcb8af2f6b4/details/',
                 {'association': True, 'engagement': True, 'leave': False,
-                 'role': True},
+                 'role': True, 'manager': False},
             )
 
         with self.subTest('employee engagement'):
@@ -1630,6 +1630,8 @@ class IntegrationTests(util.LoRATestCase):
                 ],
             )
 
+        with self.subTest('role'):
+
             self.assertRequestResponse(
                 '/service/e/1ce40e25-6238-4202-9e93-526b348ec745'
                 '/details/role',
@@ -1689,6 +1691,8 @@ class IntegrationTests(util.LoRATestCase):
                     },
                 ],
             )
+
+        with self.subTest('leave'):
 
             self.assertRequestResponse(
                 '/service/e/1ce40e25-6238-4202-9e93-526b348ec745'

--- a/tests/test_integration_manager.py
+++ b/tests/test_integration_manager.py
@@ -1,0 +1,979 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+from unittest.mock import patch
+
+import freezegun
+
+from mora import lora
+from tests import util
+
+mock_uuid = '1eb680cd-d8ec-4fd2-8ca0-dce2d03f59a5'
+
+
+@freezegun.freeze_time('2017-01-01', tz_offset=1)
+@patch('mora.service.leave.uuid.uuid4', new=lambda: mock_uuid)
+class Tests(util.LoRATestCase):
+    maxDiff = None
+
+    def test_create_manager(self):
+        self.load_sample_structures()
+
+        # Check the POST request
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
+        userid = "6ee24785-ee9a-4502-81c2-7697009c9053"
+
+        payload = [
+            {
+                "type": "manager",
+                "org_unit": {'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"},
+                "responsibility": {
+                    'uuid': "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"},
+                "manager_type": {
+                    'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"
+                },
+                "manager_level": {
+                    "uuid": "1edc778c-bf9b-4e7e-b287-9adecd6ee293"
+                },
+                "validity": {
+                    "from": "2017-12-01T00:00:00+01",
+                    "to": "2017-12-02T00:00:00+01",
+                },
+            }
+        ]
+
+        self.assertRequestResponse('/service/e/{}/create'.format(userid),
+                                   userid, json=payload)
+
+        expected = {
+            "livscykluskode": "Opstaaet",
+            "tilstande": {
+                "organisationfunktiongyldighed": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "gyldighed": "Aktiv"
+                    }
+                ]
+            },
+            "note": "Oprettet i MO",
+            "relationer": {
+                "tilknyttedeorganisationer": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                    }
+                ],
+                "tilknyttedebrugere": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "6ee24785-ee9a-4502-81c2-7697009c9053"
+                    }
+                ],
+                "opgaver": [
+                    {
+                        "objekttype": "lederniveau",
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "1edc778c-bf9b-4e7e-b287-9adecd6ee293"
+                    },
+                    {
+                        "objekttype": "lederansvar",
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
+                    },
+                ],
+                "organisatoriskfunktionstype": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
+                    }
+                ],
+                "tilknyttedeenheder": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"
+                    }
+                ],
+            },
+            "attributter": {
+                "organisationfunktionegenskaber": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-12-02 00:00:00+01",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "brugervendtnoegle": mock_uuid,
+                        "funktionsnavn": "Leder"
+                    }
+                ]
+            }
+        }
+
+        managers = c.organisationfunktion.fetch(tilknyttedebrugere=userid)
+        self.assertEqual(len(managers), 1)
+        managerid = managers[0]
+
+        actual_manager = c.organisationfunktion.get(managerid)
+
+        # drop lora-generated timestamps & users
+        del actual_manager['fratidspunkt'], actual_manager[
+            'tiltidspunkt'], actual_manager[
+            'brugerref']
+
+        self.assertEqual(actual_manager, expected)
+
+    def test_create_manager_no_valid_to(self):
+        self.load_sample_structures()
+
+        # Check the POST request
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
+        userid = "6ee24785-ee9a-4502-81c2-7697009c9053"
+
+        payload = [
+            {
+                "type": "manager",
+                "org_unit": {'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"},
+                "responsibility": {
+                    'uuid': "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"},
+                "manager_type": {
+                    'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"
+                },
+                "manager_level": {
+                    "uuid": "1edc778c-bf9b-4e7e-b287-9adecd6ee293"
+                },
+                "validity": {
+                    "from": "2017-12-01T00:00:00+01",
+                },
+            }
+        ]
+
+        self.assertRequestResponse('/service/e/{}/create'.format(userid),
+                                   userid, json=payload)
+
+        expected = {
+            "livscykluskode": "Opstaaet",
+            "tilstande": {
+                "organisationfunktiongyldighed": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "gyldighed": "Aktiv"
+                    }
+                ]
+            },
+            "note": "Oprettet i MO",
+            "relationer": {
+                "tilknyttedeorganisationer": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                    }
+                ],
+                "tilknyttedebrugere": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "6ee24785-ee9a-4502-81c2-7697009c9053"
+                    }
+                ],
+                "opgaver": [
+                    {
+                        "objekttype": "lederniveau",
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "1edc778c-bf9b-4e7e-b287-9adecd6ee293"
+                    },
+                    {
+                        "objekttype": "lederansvar",
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
+                    },
+                ],
+                "organisatoriskfunktionstype": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
+                    }
+                ],
+                "tilknyttedeenheder": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"
+                    }
+                ],
+            },
+            "attributter": {
+                "organisationfunktionegenskaber": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "infinity",
+                            "from_included": True,
+                            "from": "2017-12-01 00:00:00+01"
+                        },
+                        "brugervendtnoegle": mock_uuid,
+                        "funktionsnavn": "Leder"
+                    }
+                ]
+            }
+        }
+
+        managers = c.organisationfunktion.fetch(tilknyttedebrugere=userid)
+        self.assertEqual(len(managers), 1)
+        managerid = managers[0]
+
+        actual_manager = c.organisationfunktion.get(managerid)
+
+        # drop lora-generated timestamps & users
+        del actual_manager['fratidspunkt'], actual_manager[
+            'tiltidspunkt'], actual_manager[
+            'brugerref']
+
+        self.assertEqual(actual_manager, expected)
+
+    def test_edit_manager_no_overwrite(self):
+        self.load_sample_structures()
+
+        userid = "53181ed2-f1de-4c4a-a8fd-ab358c2c454a"
+
+        manager_uuid = '05609702-977f-4869-9fb4-50ad74c6999a'
+
+        req = [{
+            "type": "manager",
+            "uuid": manager_uuid,
+            "data": {
+                "org_unit": {
+                    'uuid': "6dcc5b0e-789f-46a0-85be-f7a67a507f0e"
+                },
+                "responsibility": {
+                    'uuid': "64dcaca7-daff-4d9f-b4a9-78f2920e8e50"
+                },
+                "manager_level": {
+                    "uuid": "49c40b10-3c49-4396-88b0-792cca787a3a"
+                },
+                "manager_type": {
+                    'uuid': "052c7457-6bbe-4014-9149-c5f75af2058f"
+                },
+                "validity": {
+                    "from": "2018-04-01T00:00:00+02",
+                },
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/e/{}/edit'.format(userid),
+            userid, json=req)
+
+        expected_manager = {
+            "note": "Rediger leder",
+            "relationer": {
+                "opgaver": [
+                    {
+                        "objekttype": "lederniveau",
+                        "uuid": "49c40b10-3c49-4396-88b0-792cca787a3a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "objekttype": "lederniveau",
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                    {
+                        "objekttype": "lederansvar",
+                        "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                    {
+                        "objekttype": "lederansvar",
+                        "uuid": "64dcaca7-daff-4d9f-b4a9-78f2920e8e50",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                ],
+                "organisatoriskfunktionstype": [
+                    {
+                        "uuid": "052c7457-6bbe-4014-9149-c5f75af2058f",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                ],
+                "tilknyttedeorganisationer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "tilknyttedeenheder": [
+                    {
+                        "uuid": "6dcc5b0e-789f-46a0-85be-f7a67a507f0e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                ],
+                "tilknyttedebrugere": [
+                    {
+                        "uuid": "53181ed2-f1de-4c4a-a8fd-ab358c2c454a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+            },
+            "livscykluskode": "Rettet",
+            "tilstande": {
+                "organisationfunktiongyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    }
+                ]
+            },
+            "attributter": {
+                "organisationfunktionegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "be736ee5-5c44-4ed9-"
+                                             "b4a4-15ffa19e2848",
+                        "funktionsnavn": "Leder"
+                    }
+                ]
+            },
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual_manager = c.organisationfunktion.get(manager_uuid)
+
+        # drop lora-generated timestamps & users
+        del actual_manager['fratidspunkt'], actual_manager[
+            'tiltidspunkt'], actual_manager[
+            'brugerref']
+
+        self.assertEqual(expected_manager, actual_manager)
+
+    def test_edit_manager_overwrite(self):
+        self.load_sample_structures()
+
+        userid = "53181ed2-f1de-4c4a-a8fd-ab358c2c454a"
+
+        manager_uuid = '05609702-977f-4869-9fb4-50ad74c6999a'
+
+        req = [{
+            "type": "manager",
+            "uuid": manager_uuid,
+            "original": {
+                "org_unit": {
+                    'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"
+                },
+                "responsibility": {
+                    'uuid': "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6"
+                },
+                "manager_level": {
+                    "uuid": "8f36a442-3066-468d-b186-52c6b7c14c39"
+                },
+                "manager_type": {
+                    'uuid': "32547559-cfc1-4d97-94c6-70b192eff825"
+                },
+                "validity": {
+                    "from": "2017-01-01 00:00:00+01:00",
+                    "to": None,
+                },
+            },
+            "data": {
+                "org_unit": {
+                    'uuid': "6dcc5b0e-789f-46a0-85be-f7a67a507f0e"
+                },
+                "responsibility": {
+                    'uuid': "64dcaca7-daff-4d9f-b4a9-78f2920e8e50"
+                },
+                "manager_level": {
+                    "uuid": "49c40b10-3c49-4396-88b0-792cca787a3a"
+                },
+                "manager_type": {
+                    'uuid': "052c7457-6bbe-4014-9149-c5f75af2058f"
+                },
+                "validity": {
+                    "from": "2018-04-01T00:00:00+02",
+                },
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/e/{}/edit'.format(userid),
+            userid, json=req)
+
+        expected_manager = {
+            "note": "Rediger leder",
+            "relationer": {
+                "opgaver": [
+                    {
+                        "objekttype": "lederniveau",
+                        "uuid": "49c40b10-3c49-4396-88b0-792cca787a3a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "objekttype": "lederniveau",
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                    {
+                        "objekttype": "lederansvar",
+                        "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                    {
+                        "objekttype": "lederansvar",
+                        "uuid": "64dcaca7-daff-4d9f-b4a9-78f2920e8e50",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                ],
+                "organisatoriskfunktionstype": [
+                    {
+                        "uuid": "052c7457-6bbe-4014-9149-c5f75af2058f",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                ],
+                "tilknyttedeorganisationer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "tilknyttedeenheder": [
+                    {
+                        "uuid": "6dcc5b0e-789f-46a0-85be-f7a67a507f0e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    },
+                ],
+                "tilknyttedebrugere": [
+                    {
+                        "uuid": "53181ed2-f1de-4c4a-a8fd-ab358c2c454a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+            },
+            "livscykluskode": "Rettet",
+            "tilstande": {
+                "organisationfunktiongyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "gyldighed": "Inaktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2018-04-01 00:00:00+02"
+                        }
+                    }
+                ]
+            },
+            "attributter": {
+                "organisationfunktionegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "be736ee5-5c44-4ed9-"
+                                             "b4a4-15ffa19e2848",
+                        "funktionsnavn": "Leder"
+                    }
+                ]
+            },
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual_manager = c.organisationfunktion.get(manager_uuid)
+
+        # drop lora-generated timestamps & users
+        del actual_manager['fratidspunkt'], actual_manager[
+            'tiltidspunkt'], actual_manager[
+            'brugerref']
+
+        self.assertEqual(expected_manager, actual_manager)
+
+    def test_terminate_manager(self):
+        self.load_sample_structures()
+
+        # Check the POST request
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
+        userid = "53181ed2-f1de-4c4a-a8fd-ab358c2c454a"
+
+        payload = {"valid_from": "2017-12-01T00:00:00+01"}
+
+        self.assertRequestResponse('/service/e/{}/terminate'.format(userid),
+                                   userid, json=payload)
+
+        expected = {
+            "note": "Afslut medarbejder",
+            "relationer": {
+                "opgaver": [
+                    {
+                        "objekttype": "lederansvar",
+                        "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "objekttype": "lederniveau",
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "organisatoriskfunktionstype": [
+                    {
+                        "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "tilknyttedeorganisationer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "tilknyttedeenheder": [
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                ],
+                "tilknyttedebrugere": [
+                    {
+                        "uuid": "53181ed2-f1de-4c4a-a8fd-ab358c2c454a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+            },
+            "livscykluskode": "Rettet",
+            "tilstande": {
+                "organisationfunktiongyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "2017-12-01 00:00:00+01"
+                        }
+                    },
+                    {
+                        "gyldighed": "Inaktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-12-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                ]
+            },
+            "attributter": {
+                "organisationfunktionegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "be736ee5-5c44-4ed9-"
+                                             "b4a4-15ffa19e2848",
+                        "funktionsnavn": "Leder"
+                    }
+                ]
+            },
+        }
+
+        manager_uuid = '05609702-977f-4869-9fb4-50ad74c6999a'
+
+        actual_manager = c.organisationfunktion.get(manager_uuid)
+
+        # drop lora-generated timestamps & users
+        del actual_manager['fratidspunkt'], actual_manager[
+            'tiltidspunkt'], actual_manager[
+            'brugerref']
+
+        self.assertEqual(actual_manager, expected)
+
+    def test_edit_manager_minimal(self):
+        # We are expanding the validity times on the object, so we insert a
+        # separate copy as to not 'taint' the fixtures, as LoRa is unable to
+        #  properly delete objects without the validities bleeding through
+        manager_uuid = "06137e23-dcd1-49e8-9247-09563bae4bcd"
+        util.load_fixture(
+            'organisation/organisationfunktion',
+            'create_organisationfunktion_leder.json', manager_uuid)
+
+        userid = "53181ed2-f1de-4c4a-a8fd-ab358c2c454a"
+
+        req = [{
+            "type": "manager",
+            "uuid": manager_uuid,
+            "data": {
+                "responsibility": {
+                    'uuid': "23c1d210-a52f-4f7e-85fa-856b03b2789e"
+                },
+                "validity": {
+                    "from": "2014-04-01T00:00:00+02",
+                },
+            },
+        }]
+
+        self.assertRequestResponse(
+            '/service/e/{}/edit'.format(userid),
+            userid, json=req)
+
+        expected_manager = {
+            "note": "Rediger leder",
+            "relationer": {
+                "opgaver": [
+                    {
+                        "objekttype": "lederansvar",
+                        "uuid": "23c1d210-a52f-4f7e-85fa-856b03b2789e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "objekttype": "lederniveau",
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                ],
+                "organisatoriskfunktionstype": [
+                    {
+                        "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "tilknyttedeorganisationer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "tilknyttedeenheder": [
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                ],
+                "tilknyttedebrugere": [
+                    {
+                        "uuid": "53181ed2-f1de-4c4a-a8fd-ab358c2c454a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+            },
+            "livscykluskode": "Rettet",
+            "tilstande": {
+                "organisationfunktiongyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    }
+                ]
+            },
+            "attributter": {
+                "organisationfunktionegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2014-04-01 00:00:00+02",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "be736ee5-5c44-4ed9-"
+                                             "b4a4-15ffa19e2848",
+                        "funktionsnavn": "Leder"
+                    }
+                ]
+            },
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual_manager = c.organisationfunktion.get(manager_uuid)
+
+        # drop lora-generated timestamps & users
+        del actual_manager['fratidspunkt'], actual_manager[
+            'tiltidspunkt'], actual_manager[
+            'brugerref']
+
+        self.assertEqual(actual_manager, expected_manager)

--- a/tests/test_integration_service.py
+++ b/tests/test_integration_service.py
@@ -44,7 +44,7 @@ class Tests(util.LoRATestCase):
             'user_key': 'AU',
             'unit_count': 1,
             'person_count': 2,
-            'employment_count': 4,
+            'employment_count': 1,
             'child_count': 1,
         }
 
@@ -798,6 +798,94 @@ class Tests(util.LoRATestCase):
         self.assertRequestResponse(
             '/service/e/00000000-0000-0000-0000-000000000000'
             '/details/leave',
+            [],
+        )
+
+    def test_manager(self):
+        self.load_sample_structures()
+
+        func = [
+            {
+                'manager_level': {
+                    'example': None,
+                    'name': 'Institut',
+                    'scope': None,
+                    'user_key': 'inst',
+                    'uuid': 'ca76a441-6226-404f-88a9-31e02e420e52',
+                },
+                'person': {
+                    'name': 'Anders And',
+                    'uuid': '53181ed2-f1de-4c4a-a8fd-ab358c2c454a',
+                },
+                'org_unit': {
+                    "name": "Humanistisk fakultet",
+                    "user_key": "hum",
+                    "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                },
+                'manager_type': {
+                    'example': None,
+                    'name': 'Afdeling',
+                    'scope': None,
+                    'user_key': 'afd',
+                    'uuid': '32547559-cfc1-4d97-94c6-70b192eff825',
+                },
+                'responsibility': {
+                    'example': None,
+                    'name': 'Fakultet',
+                    'scope': None,
+                    'user_key': 'fak',
+                    'uuid': '4311e351-6a3c-4e7e-ae60-8a3b2938fbd6'
+                },
+                'uuid': '05609702-977f-4869-9fb4-50ad74c6999a',
+                "validity": {
+                    'from': '2017-01-01T00:00:00+01:00',
+                    'to': None,
+                },
+            },
+        ]
+
+        with self.subTest('user'):
+            self.assertRequestResponse(
+                '/service/e/53181ed2-f1de-4c4a-a8fd-ab358c2c454a'
+                '/details/manager',
+                func,
+            )
+
+        with self.subTest('past'):
+            self.assertRequestResponse(
+                '/service/e/53181ed2-f1de-4c4a-a8fd-ab358c2c454a'
+                '/details/manager?validity=past',
+                [],
+            )
+
+        with self.subTest('future'):
+            self.assertRequestResponse(
+                '/service/e/53181ed2-f1de-4c4a-a8fd-ab358c2c454a'
+                '/details/manager?validity=future',
+                [],
+            )
+
+            self.assertRequestResponse(
+                '/service/e/53181ed2-f1de-4c4a-a8fd-ab358c2c454a'
+                '/details/manager?at=2016-01-01&validity=future',
+                func,
+            )
+
+        self.assertRequestResponse(
+            '/service/ou/9d07123e-47ac-4a9a-88c8-da82e3a4bc9e'
+            '/details/manager',
+            func,
+        )
+
+        self.assertRequestResponse(
+            '/service/e/6ee24785-ee9a-4502-81c2-7697009c9053'
+            '/details/manager',
+            [],
+        )
+
+        self.assertRequestResponse(
+            '/service/e/00000000-0000-0000-0000-000000000000'
+            '/details/manager',
             [],
         )
 

--- a/tests/test_integration_service.py
+++ b/tests/test_integration_service.py
@@ -45,6 +45,10 @@ class Tests(util.LoRATestCase):
             'unit_count': 1,
             'person_count': 2,
             'employment_count': 1,
+            'association_count': 1,
+            'leave_count': 1,
+            'role_count': 1,
+            'manager_count': 1,
             'child_count': 1,
         }
 

--- a/tests/test_service_common.py
+++ b/tests/test_service_common.py
@@ -11,7 +11,8 @@ from unittest import TestCase
 from mora import util
 from mora.service.common import (FieldTuple, FieldTypes, get_obj_value,
                                  update_payload, inactivate_old_interval,
-                                 ensure_bounds, _merge_obj_effects)
+                                 ensure_bounds, _merge_obj_effects,
+                                 set_object_value)
 
 
 class TestClass(TestCase):
@@ -1563,6 +1564,49 @@ class TestClass(TestCase):
 
         actual_result = sorted(actual_result,
                                key=lambda x: x.get('virkning').get('from'))
+
+        # Assert
+        self.assertEqual(expected_result, actual_result)
+
+    def test_set_object_value_existing_path(self):
+        # Arrange
+        obj = {'test1': {'test2': [{'key1': 'val1'}]}}
+        path = ('test1', 'test2')
+
+        val = [{'key2': 'val2'}]
+
+        expected_result = {
+            'test1': {
+                'test2': [
+                    {'key1': 'val1'},
+                    {'key2': 'val2'},
+                ]
+            }
+        }
+
+        # Act
+        actual_result = set_object_value(obj, path, val)
+
+        # Assert
+        self.assertEqual(expected_result, actual_result)
+
+    def test_set_object_value_new_path(self):
+        # Arrange
+        obj = {}
+        path = ('test1', 'test2')
+
+        val = [{'key2': 'val2'}]
+
+        expected_result = {
+            'test1': {
+                'test2': [
+                    {'key2': 'val2'},
+                ]
+            }
+        }
+
+        # Act
+        actual_result = set_object_value(obj, path, val)
 
         # Assert
         self.assertEqual(expected_result, actual_result)

--- a/tests/util.py
+++ b/tests/util.py
@@ -127,6 +127,7 @@ def load_sample_structures(*, verbose=False, minimal=False, check=False):
         'tilknytning': 'c2153d5d-4a2b-492d-a18c-c498f7bb6221',
         'rolle': '1b20d0b9-96a0-42a6-b196-293bb86e62e8',
         'orlov': 'b807628c-030c-4f5f-a438-de41c1f26ba5',
+        'leder': '05609702-977f-4869-9fb4-50ad74c6999a',
     }
 
     users = {


### PR DESCRIPTION
Implemented reading and writing of Manager in the usual fashion.
The code for creating new org funk objects has become even more contrived due to having to special handling of 'opgaver' -- it works for now, but will be overhauled in the near future hopefully, along with all of the nearly identical code in the edit functions for each org funk type.