### PR TITLE
Feature/org unit writing

### DIFF
--- a/mora/service/association.py
+++ b/mora/service/association.py
@@ -102,7 +102,7 @@ def edit_association(employee_uuid, req):
 
     if keys.ORG_UNIT in data.keys():
         update_fields.append((
-            mapping.ORG_UNIT_FIELD,
+            mapping.ASSOCIATED_ORG_UNIT_FIELD,
             {'uuid': data.get(keys.ORG_UNIT).get('uuid')},
         ))
 

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -379,6 +379,62 @@ def create_organisationsfunktion_payload(
     return org_funk
 
 
+def create_organisationsenhed_payload(
+    enhedsnavn: str,
+    valid_from: str,
+    valid_to: str,
+    brugervendtnoegle: str,
+    tilhoerer: str,
+    enhedstype: str,
+    overordnet: str,
+    adresser: List[dict] = None,
+) -> dict:
+
+    virkning = _create_virkning(valid_from, valid_to)
+
+    org_unit = {
+        'note': 'Oprettet i MO',
+        'attributter': {
+            'organisationenhedegenskaber': [
+                {
+                    'enhedsnavn': enhedsnavn,
+                    'brugervendtnoegle': brugervendtnoegle
+                },
+            ],
+        },
+        'tilstande': {
+            'organisationenhedgyldighed': [
+                {
+                    'gyldighed': 'Aktiv',
+                },
+            ],
+        },
+        'relationer': {
+            'tilhoerer': [
+                {
+                    'uuid': tilhoerer
+                }
+            ],
+            'enhedstype': [
+                {
+                    'uuid': enhedstype
+                }
+            ],
+            'overordnet': [
+                {
+                    'uuid': overordnet
+                }
+            ],
+        }
+    }
+    if adresser:
+        org_unit['relationer']['adresser'] = adresser
+
+    org_unit = _set_virkning(org_unit, virkning)
+
+    return org_unit
+
+
 def get_valid_from(obj, fallback=None):
     sentinel = object()
     validity = obj.get(keys.VALIDITY, sentinel)

--- a/mora/service/engagement.py
+++ b/mora/service/engagement.py
@@ -503,7 +503,7 @@ def edit_engagement(employee_uuid, req):
 
     if keys.ORG_UNIT in data.keys():
         update_fields.append((
-            mapping.ORG_UNIT_FIELD,
+            mapping.ASSOCIATED_ORG_UNIT_FIELD,
             {'uuid': data.get(keys.ORG_UNIT).get('uuid')},
         ))
 

--- a/mora/service/keys.py
+++ b/mora/service/keys.py
@@ -56,6 +56,9 @@ RESPONSIBILITY = 'responsibility'
 
 # Org unit
 ORG_UNIT_TYPE = 'org_unit_type'
+NAME = 'name'
+PARENT = 'parent'
+ADDRESSES = 'addresses'
 
 FUNCTION_KEYS = {
     'engagement': ENGAGEMENT_KEY,

--- a/mora/service/manager.py
+++ b/mora/service/manager.py
@@ -110,7 +110,7 @@ def edit_manager(employee_uuid, req):
 
     if keys.ORG_UNIT in data.keys():
         update_fields.append((
-            mapping.ORG_UNIT_FIELD,
+            mapping.ASSOCIATED_ORG_UNIT_FIELD,
             {'uuid': data.get(keys.ORG_UNIT).get('uuid')},
         ))
 

--- a/mora/service/mapping.py
+++ b/mora/service/mapping.py
@@ -20,6 +20,12 @@ ORG_FUNK_EGENSKABER_FIELD = FieldTuple(
     filter_fn=lambda x: True
 )
 
+ORG_FUNK_TYPE_FIELD = FieldTuple(
+    path=('relationer', 'organisatoriskfunktionstype'),
+    type=FieldTypes.ZERO_TO_ONE,
+    filter_fn=lambda x: True
+)
+
 JOB_FUNCTION_FIELD = FieldTuple(
     path=('relationer', 'opgaver'),
     type=FieldTypes.ADAPTED_ZERO_TO_MANY,
@@ -32,15 +38,45 @@ ORG_FUNK_TYPE_FIELD = FieldTuple(
     filter_fn=lambda x: True
 )
 
-ORG_UNIT_FIELD = FieldTuple(
+ASSOCIATED_ORG_UNIT_FIELD = FieldTuple(
     path=('relationer', 'tilknyttedeenheder'),
     type=FieldTypes.ADAPTED_ZERO_TO_MANY,
     filter_fn=lambda x: True
 )
 
-ORG_FIELD = FieldTuple(
+ASSOCIATED_ORG_FIELD = FieldTuple(
     path=('relationer', 'tilknyttedeorganisationer'),
     type=FieldTypes.ADAPTED_ZERO_TO_MANY,
+    filter_fn=lambda x: True
+)
+
+ORG_UNIT_GYLDIGHED_FIELD = FieldTuple(
+    path=('tilstande', 'organisationenhedgyldighed'),
+    type=FieldTypes.ZERO_TO_ONE,
+    filter_fn=lambda x: True
+)
+
+ORG_UNIT_EGENSKABER_FIELD = FieldTuple(
+    path=('attributter', 'organisationenhedegenskaber'),
+    type=FieldTypes.ZERO_TO_ONE,
+    filter_fn=lambda x: True
+)
+
+ORG_UNIT_TYPE_FIELD = FieldTuple(
+    path=('relationer', 'enhedstype'),
+    type=FieldTypes.ZERO_TO_ONE,
+    filter_fn=lambda x: True
+)
+
+PARENT_FIELD = FieldTuple(
+    path=('relationer', 'overordnet'),
+    type=FieldTypes.ZERO_TO_ONE,
+    filter_fn=lambda x: True
+)
+
+BELONGS_TO_FIELD = FieldTuple(
+    path=('relationer', 'tilhoerer'),
+    type=FieldTypes.ZERO_TO_ONE,
     filter_fn=lambda x: True
 )
 
@@ -74,13 +110,19 @@ MANAGER_LEVEL_FIELD = FieldTuple(
     filter_fn=lambda x: x['objekttype'] == 'lederniveau'
 )
 
+ITSYSTEMS_FIELD = FieldTuple(
+    path=('relationer', 'tilknyttedeitsystemer'),
+    type=FieldTypes.ZERO_TO_MANY,
+    filter_fn=lambda x: True
+)
+
 ENGAGEMENT_FIELDS = {
     ORG_FUNK_EGENSKABER_FIELD,
     ORG_FUNK_GYLDIGHED_FIELD,
     JOB_FUNCTION_FIELD,
     ORG_FUNK_TYPE_FIELD,
-    ORG_UNIT_FIELD,
-    ORG_FIELD,
+    ASSOCIATED_ORG_UNIT_FIELD,
+    ASSOCIATED_ORG_FIELD,
     USER_FIELD
 }
 
@@ -89,8 +131,8 @@ ASSOCIATION_FIELDS = {
     ORG_FUNK_GYLDIGHED_FIELD,
     JOB_FUNCTION_FIELD,
     ORG_FUNK_TYPE_FIELD,
-    ORG_UNIT_FIELD,
-    ORG_FIELD,
+    ASSOCIATED_ORG_UNIT_FIELD,
+    ASSOCIATED_ORG_FIELD,
     USER_FIELD,
     # ADDRESSES_FIELD
 }
@@ -99,8 +141,8 @@ ROLE_FIELDS = {
     ORG_FUNK_EGENSKABER_FIELD,
     ORG_FUNK_GYLDIGHED_FIELD,
     ORG_FUNK_TYPE_FIELD,
-    ORG_UNIT_FIELD,
-    ORG_FIELD,
+    ASSOCIATED_ORG_UNIT_FIELD,
+    ASSOCIATED_ORG_FIELD,
     USER_FIELD,
 }
 
@@ -108,7 +150,7 @@ LEAVE_FIELDS = {
     ORG_FUNK_EGENSKABER_FIELD,
     ORG_FUNK_GYLDIGHED_FIELD,
     ORG_FUNK_TYPE_FIELD,
-    ORG_FIELD,
+    ASSOCIATED_ORG_FIELD,
     USER_FIELD,
 }
 
@@ -116,11 +158,20 @@ MANAGER_FIELDS = {
     ORG_FUNK_EGENSKABER_FIELD,
     ORG_FUNK_GYLDIGHED_FIELD,
     ORG_FUNK_TYPE_FIELD,
-    ORG_UNIT_FIELD,
-    ORG_FIELD,
+    ASSOCIATED_ORG_UNIT_FIELD,
+    ASSOCIATED_ORG_FIELD,
     USER_FIELD,
     RESPONSIBILITY_FIELD,
     MANAGER_LEVEL_FIELD,
+}
+
+ORG_UNIT_FIELDS = {
+    ORG_UNIT_EGENSKABER_FIELD,
+    ORG_UNIT_GYLDIGHED_FIELD,
+    ADDRESSES_FIELD,
+    BELONGS_TO_FIELD,
+    ORG_UNIT_TYPE_FIELD,
+    PARENT_FIELD
 }
 
 ITSYSTEMS_FIELD = FieldTuple(

--- a/mora/service/org.py
+++ b/mora/service/org.py
@@ -17,11 +17,16 @@ organisational units.
 
 import enum
 import operator
+import uuid
 
 import flask
 import werkzeug
 
-from . import common, keys
+from mora import lora
+from . import mapping
+from .common import (create_organisationsenhed_payload, _create_virkning,
+                     inactivate_old_interval, set_object_value, update_payload,
+                     ensure_bounds)
 from .. import util
 from . import common
 from . import keys
@@ -456,3 +461,235 @@ def list_orgunits(orgid):
             **kwargs,
         )
     ])
+
+
+@blueprint.route('/ou/create', methods=['POST'])
+def create_org_unit():
+    """Creates new organisational unit
+
+    .. :quickref: Unit; Create
+
+    :statuscode 200: Creation succeeded.
+
+    **Example Request**:
+
+    Request payload contains a list of creation objects, each differentiated
+    by the attribute 'type'. Each of these object types are detailed below:
+
+    :<json string name: The name of the org unit
+    :<json string parent: The parent org unit
+    :<json string org_unit_type: The type of org unit
+    :<json list addresses: A list of address objects.
+    :<json object validity: The validity of the created object.
+
+    Validity objects are defined as such:
+
+    :<jsonarr string from: The from date, in ISO 8601.
+    :<jsonarr string to: The to date, in ISO 8601.
+
+    .. sourcecode:: json
+
+      {
+        "name": "Name",
+        "parent": {
+          "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
+        },
+        "org_unit_type": {
+          "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
+        },
+        "valid_from": "2016-01-01T00:00:00+00:00",
+        "valid_to": "2018-01-01T00:00:00+00:00"
+      }
+
+    """
+
+    c = lora.Connector()
+
+    req = flask.request.get_json()
+
+    name = req.get(keys.NAME)
+    parent_uuid = req.get(keys.PARENT).get('uuid')
+    organisationenhed_get = c.organisationenhed.get(parent_uuid)
+    org_uuid = organisationenhed_get['relationer']['tilhoerer'][0]['uuid']
+    org_unit_type_uuid = req.get(keys.ORG_UNIT_TYPE).get('uuid')
+    # addresses = req.get(keys.ADDRESSES)
+    valid_from = common.get_valid_from(req)
+    valid_to = common.get_valid_to(req)
+
+    # TODO
+    bvn = "{} {}".format(name, uuid.uuid4())
+
+    # TODO: Process address objects
+
+    org_unit = create_organisationsenhed_payload(
+        valid_from=valid_from,
+        valid_to=valid_to,
+        enhedsnavn=name,
+        brugervendtnoegle=bvn,
+        tilhoerer=org_uuid,
+        enhedstype=org_unit_type_uuid,
+        overordnet=parent_uuid,
+        # adresser=addresses,
+    )
+
+    unitid = c.organisationenhed.create(org_unit)
+
+    return flask.jsonify(unitid)
+
+
+@blueprint.route('/ou/<uuid:unitid>/edit', methods=['POST'])
+def edit_org_unit(unitid):
+    """Edits an organisational unit
+
+    .. :quickref: Unit; Edit
+
+    :statuscode 200: The edit succeeded.
+
+    **Example Request**:
+
+    :param unitid: The UUID of the organisational unit.
+
+    :<json object original: An **optional** object containing the original
+        state of the org unit to be overwritten. If supplied, the change will
+        modify the existing registration on the org unit object.
+        Detailed below.
+    :<json object data: An object containing the changes to be made to the
+        org unit. Detailed below.
+
+    The **original** and **data** objects follow the same structure.
+    Every field in **original** is required, whereas **data** only needs
+    to contain the fields that need to change along with the validity dates.
+
+    :<jsonarr string name: The name of the org unit
+    :<jsonarr string parent: The parent org unit
+    :<jsonarr string org_unit_type: The type of org unit
+    :<jsonarr object validity: The validities of the changes.
+
+    Validity objects are defined as such:
+
+    :<jsonarr string from: The from date, in ISO 8601.
+    :<jsonarr string to: The to date, in ISO 8601.
+
+    .. sourcecode:: json
+
+      {
+        "original": {
+          "name": "Pandekagehuset",
+          "parent": {
+            "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
+          },
+          "org_unit_type": {
+            "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
+          },
+          "validity": {
+            "from": "2016-01-01T00:00:00+00:00",
+            "to": null
+          }
+        },
+        "data": {
+          "name": "Vaffelhuset",
+          "validity": {
+            "from": "2016-01-01T00:00:00+00:00",
+          }
+        }
+      }
+    """
+
+    req = flask.request.get_json()
+
+    # Get the current org-unit which the user wants to change
+    c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+    original = c.organisationenhed.get(uuid=unitid)
+
+    data = req.get('data')
+    new_from = common.get_valid_from(data)
+    new_to = common.get_valid_to(data)
+
+    payload = dict()
+    payload['note'] = 'Rediger organisationsenhed'
+
+    original_data = req.get('original')
+    if original_data:
+        # We are performing an update
+        old_from = common.get_valid_from(original_data)
+        old_to = common.get_valid_to(original_data)
+        payload = inactivate_old_interval(
+            old_from, old_to, new_from, new_to, payload,
+            ('tilstande', 'organisationenhedgyldighed')
+        )
+
+    update_fields = list()
+
+    # Always update gyldighed
+    update_fields.append((
+        mapping.ORG_UNIT_GYLDIGHED_FIELD,
+        {'gyldighed': "Aktiv"}
+    ))
+
+    if keys.NAME in data.keys():
+        update_fields.append((
+            mapping.ORG_UNIT_EGENSKABER_FIELD,
+            {'enhedsnavn': data[keys.NAME]}
+        ))
+
+    if keys.ORG_UNIT_TYPE in data.keys():
+        update_fields.append((
+            mapping.ORG_UNIT_TYPE_FIELD,
+            {'uuid': data[keys.ORG_UNIT_TYPE]['uuid']}
+        ))
+
+    if keys.PARENT in data.keys():
+        update_fields.append((
+            mapping.PARENT_FIELD,
+            {'uuid': data[keys.PARENT]['uuid']}
+        ))
+
+    payload = update_payload(new_from, new_to, update_fields, original,
+                             payload)
+
+    bounds_fields = list(
+        mapping.ORG_UNIT_FIELDS.difference({x[0] for x in update_fields}))
+    payload = ensure_bounds(new_from, new_to, bounds_fields, original, payload)
+
+    c.organisationenhed.update(payload, unitid)
+
+    return flask.jsonify(unitid)
+
+
+@blueprint.route('/ou/<uuid:unitid>/terminate', methods=['POST'])
+def terminate_org_unit(unitid):
+    """Terminates an organisational unit from a specified date.
+
+    .. :quickref: Unit; Terminate
+
+    :statuscode 200: The termination succeeded.
+
+    :param unitid: The UUID of the organisational unit to be terminated.
+
+    :<json string valid_from: The date on which the termination should happen,
+        in ISO 8601.
+
+    **Example Request**:
+
+    .. sourcecode:: json
+
+      {
+        "valid_from": "2016-01-01T00:00:00+00:00"
+      }
+    """
+    date = flask.request.get_json().get('valid_from')
+
+    obj_path = ('tilstande', 'organisationenhedgyldighed')
+    val_inactive = {
+        'gyldighed': 'Inaktiv',
+        'virkning': _create_virkning(date, 'infinity')
+    }
+
+    payload = set_object_value(dict(), obj_path, [val_inactive])
+    payload['note'] = 'Afslut enhed'
+
+    lora.Connector().organisationenhed.update(payload, unitid)
+
+    return flask.jsonify(unitid)
+
+    # TODO: Afkort adresser?

--- a/mora/service/role.py
+++ b/mora/service/role.py
@@ -92,7 +92,7 @@ def edit_role(employee_uuid, req):
 
     if keys.ORG_UNIT in data.keys():
         update_fields.append((
-            mapping.ORG_UNIT_FIELD,
+            mapping.ASSOCIATED_ORG_UNIT_FIELD,
             {'uuid': data.get(keys.ORG_UNIT).get('uuid')},
         ))
 

--- a/tests/test_create_orgunit.py
+++ b/tests/test_create_orgunit.py
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+import unittest
+
+from mora.service.common import (create_organisationsenhed_payload)
+
+
+class TestCreateOrgFunk(unittest.TestCase):
+    maxDiff = None
+
+    def test_create_organisationenhed(self):
+        output_org_unit = {
+            'attributter': {
+                'organisationenhedegenskaber': [{
+                    'enhedsnavn': 'enhedsnavn',
+                    'brugervendtnoegle': 'brugervendtnoegle',
+                    'virkning': {
+                        'from': '2016-01-01T00:00:00+00:00',
+                        'to': '2018-01-01T00:00:00+00:00'
+                    }
+                }]
+            },
+            'note': 'Oprettet i MO',
+            'relationer': {
+                'adresser': [
+                    {
+                        "uuid": "3491846c-ca4f-4339-a447-526fb0bfce55",
+                        'virkning': {
+                            'from': '2016-01-01T00:00:00+00:00',
+                            'to': '2018-01-01T00:00:00+00:00'
+                        }
+                    },
+                    {
+                        "uuid": "aff9cef9-52be-46a0-9db7-14b4bb259cce",
+                        'virkning': {
+                            'from': '2016-01-01T00:00:00+00:00',
+                            'to': '2018-01-01T00:00:00+00:00'
+                        }
+                    }
+                ],
+                'overordnet': [{
+                    'uuid': '47145ce1-c702-42c2-a88e-011eb09d250f',
+                    'virkning': {
+                        'from': '2016-01-01T00:00:00+00:00',
+                        'to': '2018-01-01T00:00:00+00:00'
+                    }
+                }],
+                'tilhoerer': [{
+                    'uuid': 'e0f7a6f7-2a76-45dc-b326-d49b4bb2c2b9',
+                    'virkning': {
+                        'from': '2016-01-01T00:00:00+00:00',
+                        'to': '2018-01-01T00:00:00+00:00'
+                    }
+                }],
+                'enhedstype': [{
+                    'uuid': '28d3c9f6-cce0-4649-bf73-ccbb78dc04e4',
+                    'virkning': {
+                        'from': '2016-01-01T00:00:00+00:00',
+                        'to': '2018-01-01T00:00:00+00:00'
+                    }
+                }],
+            },
+            'tilstande': {
+                'organisationenhedgyldighed': [{
+                    'virkning': {
+                        'from': '2016-01-01T00:00:00+00:00',
+                        'to': '2018-01-01T00:00:00+00:00'
+                    },
+                    'gyldighed': 'Aktiv'
+                }]
+            }
+        }
+
+        enhedsnavn = "enhedsnavn"
+        valid_from = "2016-01-01T00:00:00+00:00"
+        valid_to = "2018-01-01T00:00:00+00:00"
+        brugervendtnoegle = "brugervendtnoegle"
+        adresser = [
+            {
+                "uuid": "3491846c-ca4f-4339-a447-526fb0bfce55",
+            },
+            {
+                "uuid": "aff9cef9-52be-46a0-9db7-14b4bb259cce"
+            }
+        ]
+        tilhoerer = "e0f7a6f7-2a76-45dc-b326-d49b4bb2c2b9"
+        enhedstype = "28d3c9f6-cce0-4649-bf73-ccbb78dc04e4"
+        overordnet = "47145ce1-c702-42c2-a88e-011eb09d250f"
+
+        self.assertEqual(
+            create_organisationsenhed_payload(
+                enhedsnavn=enhedsnavn,
+                valid_from=valid_from,
+                valid_to=valid_to,
+                brugervendtnoegle=brugervendtnoegle,
+                adresser=adresser,
+                tilhoerer=tilhoerer,
+                enhedstype=enhedstype,
+                overordnet=overordnet
+            ),
+            output_org_unit)

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -127,7 +127,7 @@ class Tests(util.LoRATestCase):
 
         actual_org_unit = c.organisationenhed.get(unitid)
 
-        self.assertEqualLoRa(expected, actual_org_unit)
+        self.assertRegistrationsEqual(expected, actual_org_unit)
 
     def test_edit_org_unit_overwrite(self):
         # A generic example of editing an org unit
@@ -275,7 +275,7 @@ class Tests(util.LoRATestCase):
         c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
         actual = c.organisationenhed.get(org_unit_uuid)
 
-        self.assertEqualLoRa(expected, actual)
+        self.assertRegistrationsEqual(expected, actual)
 
     def test_edit_org_unit(self):
         # A generic example of editing an org unit
@@ -410,7 +410,7 @@ class Tests(util.LoRATestCase):
         c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
         actual = c.organisationenhed.get(org_unit_uuid)
 
-        self.assertEqualLoRa(expected, actual)
+        self.assertRegistrationsEqual(expected, actual)
 
     def test_rename_org_unit(self):
         # A generic example of editing an org unit
@@ -544,7 +544,7 @@ class Tests(util.LoRATestCase):
         c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
         actual = c.organisationenhed.get(org_unit_uuid)
 
-        self.assertEqualLoRa(expected, actual)
+        self.assertRegistrationsEqual(expected, actual)
 
     def test_move_org_unit(self):
         # A generic example of editing an org unit
@@ -678,7 +678,7 @@ class Tests(util.LoRATestCase):
         c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
         actual = c.organisationenhed.get(org_unit_uuid)
 
-        self.assertEqualLoRa(expected, actual)
+        self.assertRegistrationsEqual(expected, actual)
 
     def test_terminate_org_unit(self):
         self.load_sample_structures()
@@ -797,4 +797,4 @@ class Tests(util.LoRATestCase):
 
         actual_org_unit = c.organisationenhed.get(unitid)
 
-        self.assertEqualLoRa(expected, actual_org_unit)
+        self.assertRegistrationsEqual(expected, actual_org_unit)

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -1,0 +1,800 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+from unittest.mock import patch
+
+import freezegun
+
+from mora import lora
+from . import util
+
+mock_uuid = 'f494ad89-039d-478e-91f2-a63566554bd6'
+
+
+@freezegun.freeze_time('2017-01-01', tz_offset=1)
+@patch('mora.service.org.uuid.uuid4', new=lambda: mock_uuid)
+class Tests(util.LoRATestCase):
+    maxDiff = None
+
+    def test_create_org_unit(self):
+        self.load_sample_structures()
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
+        payload = {
+            "name": "Fake Corp",
+            "parent": {
+                'uuid': "2874e1dc-85e6-4269-823a-e1125484dfd3"
+            },
+            "org_unit_type": {
+                'uuid': "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
+            },
+            # TODO
+            "addresses": [
+
+            ],
+            "validity": {
+                "from": "2010-02-04T00:00:00+01",
+                "to": "2017-10-22T00:00:00+02",
+            }
+        }
+
+        r = self._perform_request('/service/ou/create', json=payload)
+        unitid = r.json
+
+        expected = {
+            "livscykluskode": "Opstaaet",
+            "note": "Oprettet i MO",
+            "attributter": {
+                "organisationenhedegenskaber": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-10-22 00:00:00+02",
+                            "from_included": True,
+                            "from": "2010-02-04 00:00:00+01"
+                        },
+                        "brugervendtnoegle":
+                            'Fake Corp f494ad89-039d-478e-91f2-a63566554bd6',
+                        "enhedsnavn": "Fake Corp"
+                    }
+                ]
+            },
+            "relationer": {
+                "overordnet": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-10-22 00:00:00+02",
+                            "from_included": True,
+                            "from": "2010-02-04 00:00:00+01"
+                        },
+                        "uuid": "2874e1dc-85e6-4269-823a-e1125484dfd3"
+                    }
+                ],
+                "tilhoerer": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-10-22 00:00:00+02",
+                            "from_included": True,
+                            "from": "2010-02-04 00:00:00+01"
+                        },
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                    }
+                ],
+                "enhedstype": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-10-22 00:00:00+02",
+                            "from_included": True,
+                            "from": "2010-02-04 00:00:00+01"
+                        },
+                        "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
+                    }
+                ],
+                # "addresser": [
+                #     {
+                #         "virkning": {
+                #             "to_included": False,
+                #             "to": "2017-10-22 00:00:00+02",
+                #             "from_included": True,
+                #             "from": "2010-02-04 00:00:00+01"
+                #         },
+                #         "uuid": "f494ad89-039d-478e-91f2-a63566554bd6"
+                #     }
+                # ]
+            },
+            "tilstande": {
+                "organisationenhedgyldighed": [
+                    {
+                        "virkning": {
+                            "to_included": False,
+                            "to": "2017-10-22 00:00:00+02",
+                            "from_included": True,
+                            "from": "2010-02-04 00:00:00+01"
+                        },
+                        "gyldighed": "Aktiv"
+                    }
+                ]
+            },
+        }
+
+        actual_org_unit = c.organisationenhed.get(unitid)
+
+        self.assertEqualLoRa(expected, actual_org_unit)
+
+    def test_edit_org_unit_overwrite(self):
+        # A generic example of editing an org unit
+
+        self.load_sample_structures()
+
+        org_unit_uuid = '85715fc7-925d-401b-822d-467eb4b163b6'
+
+        req = {
+            "original": {
+                "validity": {
+                    "from": "2016-01-01 00:00:00+01",
+                    "to": None
+                },
+                "parent": {
+                    'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"
+                },
+                "org_unit_type": {
+                    'uuid': "ca76a441-6226-404f-88a9-31e02e420e52"
+                },
+                "name": "Filosofisk Institut",
+            },
+            "data": {
+                "org_unit_type": {
+                    'uuid': "79e15798-7d6d-4e85-8496-dcc8887a1c1a"
+                },
+                "validity": {
+                    "from": "2017-01-01T00:00:00+01",
+                },
+            },
+        }
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            org_unit_uuid, json=req)
+
+        expected = {
+            "note": "Rediger organisationsenhed",
+            "attributter": {
+                "organisationenhedegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "fil",
+                        "enhedsnavn": "Filosofisk Institut"
+                    }
+                ]
+            },
+            "tilstande": {
+                "organisationenhedgyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "gyldighed": "Inaktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2017-01-01 00:00:00+01"
+                        }
+                    }
+                ]
+            },
+            "relationer": {
+                "tilhoerer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "overordnet": [
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "enhedstype": [
+                    {
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2017-01-01 00:00:00+01"
+                        }
+                    },
+                    {
+                        "uuid": "79e15798-7d6d-4e85-8496-dcc8887a1c1a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "adresser": [
+                    {
+                        "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "objekttype": "v0:1:Kontor",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "urn": "urn:magenta.dk:telefon:+4587150000",
+                        "objekttype": "v0:external:"
+                                      "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ]
+            },
+            "livscykluskode": "Rettet",
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual = c.organisationenhed.get(org_unit_uuid)
+
+        self.assertEqualLoRa(expected, actual)
+
+    def test_edit_org_unit(self):
+        # A generic example of editing an org unit
+
+        self.load_sample_structures()
+
+        org_unit_uuid = '85715fc7-925d-401b-822d-467eb4b163b6'
+
+        req = {
+            "data": {
+                "org_unit_type": {
+                    'uuid': "79e15798-7d6d-4e85-8496-dcc8887a1c1a"
+                },
+                "validity": {
+                    "from": "2017-01-01T00:00:00+01",
+                },
+            },
+        }
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            org_unit_uuid, json=req)
+
+        expected = {
+            "note": "Rediger organisationsenhed",
+            "attributter": {
+                "organisationenhedegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "fil",
+                        "enhedsnavn": "Filosofisk Institut"
+                    }
+                ]
+            },
+            "tilstande": {
+                "organisationenhedgyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2017-01-01 00:00:00+01"
+                        }
+                    },
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                ]
+            },
+            "relationer": {
+                "tilhoerer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "overordnet": [
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "enhedstype": [
+                    {
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2017-01-01 00:00:00+01"
+                        }
+                    },
+                    {
+                        "uuid": "79e15798-7d6d-4e85-8496-dcc8887a1c1a",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "adresser": [
+                    {
+                        "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "objekttype": "v0:1:Kontor",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "urn": "urn:magenta.dk:telefon:+4587150000",
+                        "objekttype": "v0:external:"
+                                      "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ]
+            },
+            "livscykluskode": "Rettet",
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual = c.organisationenhed.get(org_unit_uuid)
+
+        self.assertEqualLoRa(expected, actual)
+
+    def test_rename_org_unit(self):
+        # A generic example of editing an org unit
+
+        self.load_sample_structures()
+
+        org_unit_uuid = '85715fc7-925d-401b-822d-467eb4b163b6'
+
+        req = {
+            "data": {
+                "name": "Filosofisk Institut II",
+                "validity": {
+                    "from": "2018-01-01T00:00:00+01",
+                },
+            },
+        }
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            org_unit_uuid, json=req)
+
+        expected = {
+            "note": "Rediger organisationsenhed",
+            "attributter": {
+                "organisationenhedegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2018-01-01 00:00:00+01"
+                        },
+                        "brugervendtnoegle": "fil",
+                        "enhedsnavn": "Filosofisk Institut"
+                    },
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-01-01 00:00:00+01",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "fil",
+                        "enhedsnavn": "Filosofisk Institut II"
+                    },
+                ]
+            },
+            "tilstande": {
+                "organisationenhedgyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2018-01-01 00:00:00+01"
+                        }
+                    },
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2018-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                ]
+            },
+            "relationer": {
+                "tilhoerer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "overordnet": [
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "enhedstype": [
+                    {
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "adresser": [
+                    {
+                        "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "objekttype": "v0:1:Kontor",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "urn": "urn:magenta.dk:telefon:+4587150000",
+                        "objekttype": "v0:external:"
+                                      "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ]
+            },
+            "livscykluskode": "Rettet",
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual = c.organisationenhed.get(org_unit_uuid)
+
+        self.assertEqualLoRa(expected, actual)
+
+    def test_move_org_unit(self):
+        # A generic example of editing an org unit
+
+        self.load_sample_structures()
+
+        org_unit_uuid = '85715fc7-925d-401b-822d-467eb4b163b6'
+
+        req = {
+            "data": {
+                "parent": {
+                    "uuid": "235ce700-c322-4ebb-94d5-fafb5aace1b5"
+                },
+                "validity": {
+                    "from": "2017-07-01T00:00:00+02",
+                },
+            },
+        }
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            org_unit_uuid, json=req)
+
+        expected = {
+            "note": "Rediger organisationsenhed",
+            "attributter": {
+                "organisationenhedegenskaber": [
+                    {
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        },
+                        "brugervendtnoegle": "fil",
+                        "enhedsnavn": "Filosofisk Institut"
+                    }
+                ]
+            },
+            "tilstande": {
+                "organisationenhedgyldighed": [
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2017-07-01 00:00:00+02"
+                        }
+                    },
+                    {
+                        "gyldighed": "Aktiv",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-07-01 00:00:00+02",
+                            "to": "infinity"
+                        }
+                    },
+                ]
+            },
+            "relationer": {
+                "tilhoerer": [
+                    {
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "overordnet": [
+                    {
+                        "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "2017-07-01 00:00:00+02"
+                        },
+                    }, {
+                        "uuid": "235ce700-c322-4ebb-94d5-fafb5aace1b5",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2017-07-01 00:00:00+02",
+                            "to": "infinity"
+                        },
+                    }
+                ],
+                "enhedstype": [
+                    {
+                        "uuid": "ca76a441-6226-404f-88a9-31e02e420e52",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ],
+                "adresser": [
+                    {
+                        "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "objekttype": "v0:1:Kontor",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    },
+                    {
+                        "urn": "urn:magenta.dk:telefon:+4587150000",
+                        "objekttype": "v0:external:"
+                                      "b1f1817d-5f02-4331-b8b3-97330a5d3197",
+                        "virkning": {
+                            "from_included": True,
+                            "to_included": False,
+                            "from": "2016-01-01 00:00:00+01",
+                            "to": "infinity"
+                        }
+                    }
+                ]
+            },
+            "livscykluskode": "Rettet",
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual = c.organisationenhed.get(org_unit_uuid)
+
+        self.assertEqualLoRa(expected, actual)
+
+    def test_terminate_org_unit(self):
+        self.load_sample_structures()
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
+        unitid = "85715fc7-925d-401b-822d-467eb4b163b6"
+
+        payload = {
+            "valid_from": "2017-10-22T00:00:00+02",
+        }
+
+        self._perform_request('/service/ou/{}/terminate'.format(unitid),
+                              json=payload)
+
+        expected = {
+            'attributter': {
+                'organisationenhedegenskaber': [
+                    {
+                        'brugervendtnoegle': 'fil',
+                        'enhedsnavn': 'Filosofisk '
+                                      'Institut',
+                        'virkning': {
+                            'from': '2016-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False
+                        }
+                    }
+                ]
+            },
+            'livscykluskode': 'Rettet',
+            'note': 'Afslut enhed',
+            'relationer': {
+                'adresser': [
+                    {
+                        'objekttype': 'v0:1:Kontor',
+                        'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
+                        'virkning': {
+                            'from': '2016-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False
+                        }
+                    },
+                    {
+                        'objekttype':
+                            'v0:external:b1f1817d-5f02-4331-b8b3-97330a5d3197',
+                        'urn': 'urn:magenta.dk:telefon:+4587150000',
+                        'virkning': {
+                            'from': '2016-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False
+                        }
+                    }
+                ],
+                'enhedstype': [
+                    {
+                        'uuid': 'ca76a441-6226-404f-88a9-31e02e420e52',
+                        'virkning': {
+                            'from': '2016-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False
+                        }
+                    }
+                ],
+                'overordnet': [
+                    {
+                        'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                        'virkning': {
+                            'from': '2016-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False
+                        }
+                    }
+                ],
+                'tilhoerer': [
+                    {
+                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
+                        'virkning': {
+                            'from': '2016-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False
+                        }
+                    }
+                ]
+            },
+            'tilstande': {
+                'organisationenhedgyldighed': [
+                    {
+                        'gyldighed': 'Aktiv',
+                        'virkning': {
+                            'from': '2016-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': '2017-10-22 '
+                                  '00:00:00+02',
+                            'to_included': False
+                        }
+                    },
+                    {
+                        'gyldighed': 'Inaktiv',
+                        'virkning': {
+                            'from': '2017-10-22 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False
+                        }
+                    }
+                ]
+            }
+        }
+
+        actual_org_unit = c.organisationenhed.get(unitid)
+
+        self.assertEqualLoRa(expected, actual_org_unit)

--- a/tests/util.py
+++ b/tests/util.py
@@ -359,23 +359,23 @@ class TestCaseMixin(object):
 
         return self.client.open(path, **kwargs)
 
-    def sort_inner_lists(self, obj):
-        """
-        Sort all inner lists in LoRa objects ascending by the 'from' date of
-        their elements -- e.g. The list located at
-        obj['relationer']['enhedstype']
+    def assertRegistrationsEqual(self, expected, actual):
+        def sort_inner_lists(obj):
+            """
+            Sort all inner lists in LoRa objects ascending by the 'from' date
+            of their elements -- e.g. The list located at
+            obj['relationer']['enhedstype']
 
-        This is purely to help comparison tests, as we don't care about the
-        list ordering
-        """
-        obj = copy.deepcopy(obj)
-        for outer_value in filter(lambda x: type(x) is dict, obj.values()):
-            for inner_key in outer_value:
-                outer_value[inner_key] = sorted(outer_value[inner_key],
-                                                key=common.get_effect_from)
-        return obj
+            This is purely to help comparison tests, as we don't care about the
+            list ordering
+            """
+            obj = copy.deepcopy(obj)
+            for outer_value in filter(lambda x: type(x) is dict, obj.values()):
+                for inner_key in outer_value:
+                    outer_value[inner_key] = sorted(outer_value[inner_key],
+                                                    key=common.get_effect_from)
+            return obj
 
-    def assertEqualLoRa(self, expected, actual):
         # drop lora-generated timestamps & users
         del actual['fratidspunkt'], actual[
             'tiltidspunkt'], actual[
@@ -383,8 +383,8 @@ class TestCaseMixin(object):
 
         # Sort all inner lists and compare
         return self.assertEqual(
-            self.sort_inner_lists(expected),
-            self.sort_inner_lists(actual))
+            sort_inner_lists(expected),
+            sort_inner_lists(actual))
 
 
 class LoRATestCaseMixin(TestCaseMixin):

--- a/tests/util.py
+++ b/tests/util.py
@@ -21,6 +21,7 @@ import threading
 import time
 import unittest
 
+import copy
 import flask_testing
 import requests
 import requests_mock
@@ -28,6 +29,7 @@ import werkzeug.serving
 
 from mora import lora, app, settings
 from mora.converters import importing
+from mora.service import common
 
 TESTS_DIR = os.path.dirname(__file__)
 BASE_DIR = os.path.dirname(TESTS_DIR)
@@ -356,6 +358,33 @@ class TestCaseMixin(object):
             kwargs['headers'] = {'Content-Type': 'application/json'}
 
         return self.client.open(path, **kwargs)
+
+    def sort_inner_lists(self, obj):
+        """
+        Sort all inner lists in LoRa objects ascending by the 'from' date of
+        their elements -- e.g. The list located at
+        obj['relationer']['enhedstype']
+
+        This is purely to help comparison tests, as we don't care about the
+        list ordering
+        """
+        obj = copy.deepcopy(obj)
+        for outer_value in filter(lambda x: type(x) is dict, obj.values()):
+            for inner_key in outer_value:
+                outer_value[inner_key] = sorted(outer_value[inner_key],
+                                                key=common.get_effect_from)
+        return obj
+
+    def assertEqualLoRa(self, expected, actual):
+        # drop lora-generated timestamps & users
+        del actual['fratidspunkt'], actual[
+            'tiltidspunkt'], actual[
+            'brugerref']
+
+        # Sort all inner lists and compare
+        return self.assertEqual(
+            self.sort_inner_lists(expected),
+            self.sort_inner_lists(actual))
 
 
 class LoRATestCaseMixin(TestCaseMixin):


### PR DESCRIPTION
Implemented the usual writing magic for org units.
Addresses aren't handled as of yet - awaiting final implementation of address writing logic.
Renamed some of the mapping fields to something slightly more specific