### PR TITLE
tests: use a temporary file rather than a pipe

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -12,7 +12,6 @@ import json
 import os
 import pprint
 import re
-import select
 import signal
 import socket
 import subprocess
@@ -452,14 +451,17 @@ class LoRATestCaseMixin(TestCaseMixin):
         s.mount(
             settings.LORA_URL,
             requests.adapters.HTTPAdapter(
-                max_retries=urllib3.util.retry.Retry(backoff_factor=0.1),
+                max_retries=urllib3.util.retry.Retry(
+                    10,
+                    backoff_factor=0.01,
+                ),
             ),
         )
 
         try:
             s.get(settings.LORA_URL + 'site-map').raise_for_status()
         except Exception as e:
-            self.skipTest(e.message)
+            raise unittest.SkipTest('LoRA startup failed!')
 
     @classmethod
     def tearDownClass(cls):
@@ -475,12 +477,12 @@ class LoRATestCaseMixin(TestCaseMixin):
     def setUp(self):
         super().setUp()
 
-        self.assertIsNone(self.minimox.poll(), 'LoRA startup failed!')
+        self.assertIsNone(self.minimox.poll(), 'LoRA suddenly died!')
 
         self.flush_log()
 
     def tearDown(self):
-        self.assertIsNone(self.minimox.poll(), 'LoRA startup failed!')
+        self.assertIsNone(self.minimox.poll(), 'LoRA suddenly died!')
 
         self.flush_log()
 


### PR DESCRIPTION
Using a pipe can trigger a deadlock of the output from the child
process exceeds a certain limit, and we don't routinely flush/read the
pipe. Originally, we wanted to use a pipe so that we could detect when
the child was ready, and print its output.

We fix this by applying three changes:

1) Use an unnamed temporary file for output from the child.
2) Wait for the child process using the retry support in requests &
   urllib3.
3) Flush the log file regularly, so we retain a reasonably ordering of
   the output in reports from failing tests.