### PR TITLE
We now only get org units that have a gyldighed of 'Aktiv', behavling…

### DIFF
--- a/mora/service/orgunit.py
+++ b/mora/service/orgunit.py
@@ -81,7 +81,10 @@ class OrgUnit(common.AbstractRelationDetail):
                     ),
                 },
             )
-            if c.is_effect_relevant({'from': start, 'to': end})
+            if c.is_effect_relevant({'from': start, 'to': end}) and
+            effect.get('tilstande')
+                  .get('organisationenhedgyldighed')[0]
+                  .get('gyldighed') == 'Aktiv'
         ])
 
     def edit(self, id, req):

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -946,120 +946,43 @@ class Tests(util.LoRATestCase):
     def test_terminate_org_unit(self):
         self.load_sample_structures()
 
-        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
-
         unitid = "85715fc7-925d-401b-822d-467eb4b163b6"
 
         payload = {
             "validity": {
-                "from": "2017-10-22T00:00:00+02"
+                "from": "2016-10-22T00:00:00+02"
             }
         }
 
         self._perform_request('/service/ou/{}/terminate'.format(unitid),
                               json=payload)
 
-        expected = {
-            'attributter': {
-                'organisationenhedegenskaber': [
-                    {
-                        'brugervendtnoegle': 'fil',
-                        'enhedsnavn': 'Filosofisk '
-                                      'Institut',
-                        'virkning': {
-                            'from': '2016-01-01 00:00:00+01',
-                            'from_included': True,
-                            'to': 'infinity',
-                            'to_included': False
-                        }
-                    }
-                ]
-            },
-            'livscykluskode': 'Rettet',
-            'note': 'Afslut enhed',
-            'relationer': {
-                'adresser': [
-                    {
-                        'objekttype': '4e337d8e-1fd2-4449-8110-e0c8a22958ed',
-                        'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
-                        'virkning': {
-                            'from': '2016-01-01 00:00:00+01',
-                            'from_included': True,
-                            'to': 'infinity',
-                            'to_included': False
-                        }
-                    },
-                    {
-                        'objekttype':
-                            '1d1d3711-5af4-4084-99b3-df2b8752fdec',
-                        'urn': 'urn:magenta.dk:telefon:+4587150000',
-                        'virkning': {
-                            'from': '2016-01-01 00:00:00+01',
-                            'from_included': True,
-                            'to': 'infinity',
-                            'to_included': False
-                        }
-                    }
-                ],
-                'enhedstype': [
-                    {
-                        'uuid': 'ca76a441-6226-404f-88a9-31e02e420e52',
-                        'virkning': {
-                            'from': '2016-01-01 00:00:00+01',
-                            'from_included': True,
-                            'to': 'infinity',
-                            'to_included': False
-                        }
-                    }
-                ],
-                'overordnet': [
-                    {
-                        'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
-                        'virkning': {
-                            'from': '2016-01-01 00:00:00+01',
-                            'from_included': True,
-                            'to': 'infinity',
-                            'to_included': False
-                        }
-                    }
-                ],
-                'tilhoerer': [
-                    {
-                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
-                        'virkning': {
-                            'from': '2016-01-01 00:00:00+01',
-                            'from_included': True,
-                            'to': 'infinity',
-                            'to_included': False
-                        }
-                    }
-                ]
-            },
-            'tilstande': {
-                'organisationenhedgyldighed': [
-                    {
-                        'gyldighed': 'Aktiv',
-                        'virkning': {
-                            'from': '2016-01-01 00:00:00+01',
-                            'from_included': True,
-                            'to': '2017-10-22 '
-                                  '00:00:00+02',
-                            'to_included': False
-                        }
-                    },
-                    {
-                        'gyldighed': 'Inaktiv',
-                        'virkning': {
-                            'from': '2017-10-22 00:00:00+02',
-                            'from_included': True,
-                            'to': 'infinity',
-                            'to_included': False
-                        }
-                    }
-                ]
-            }
-        }
+        self.assertRequestResponse(
+            '/service/ou/{}'.format(unitid) +
+            '/details/org_unit?validity=past',
+            [
+                {'name': 'Filosofisk Institut',
+                 'org': {'name': 'Aarhus Universitet',
+                         'user_key': 'AU',
+                         'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62'},
+                 'org_unit_type': {'example': None,
+                                   'name': 'Institut',
+                                   'scope': None,
+                                   'user_key': 'inst',
+                                   'uuid': 'ca76a441-6226-404f-'
+                                           '88a9-31e02e420e52'},
+                 'parent': {'name': 'Humanistisk fakultet',
+                            'user_key': 'hum',
+                            'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e'},
+                 'user_key': 'fil',
+                 'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                 'validity': {'from': '2016-01-01T00:00:00+01:00',
+                              'to': '2016-10-22T00:00:00+02:00'}}]
+        )
 
-        actual_org_unit = c.organisationenhed.get(unitid)
-
-        self.assertRegistrationsEqual(expected, actual_org_unit)
+        # Verify that we are no longer able to see org unit
+        self.assertRequestResponse(
+            '/service/ou/{}'.format(unitid) +
+            '/details/org_unit?validity=present',
+            [],
+        )


### PR DESCRIPTION
… similarly to fetching other details.

Updated terminate test to verify this, and to also more thoroughly test functionality using the get details endpoint instead of hitting LoRa directly.