### PR TITLE
Type checking

### DIFF
--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -103,7 +103,7 @@ def checked_get(
     key: K,
     default: V,
     fallback: D=None,
-    required: bool=True,
+    required: bool=False,
 ) -> V:
     sentinel = object()
     v = mapping.get(key, sentinel)
@@ -130,7 +130,7 @@ def get_uuid(
     *,
     key: typing.Hashable=keys.UUID
 ) -> str:
-    v = checked_get(mapping, key, '', fallback=fallback)
+    v = checked_get(mapping, key, '', fallback=fallback, required=True)
 
     if not util.is_uuid(v):
         raise ValueError('invalid uuid for {!r}: {!r}'.format(key, v))

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -14,11 +14,12 @@
 import abc
 import collections
 import copy
-import enum
 import datetime
+import enum
 import functools
-import uuid
+import json
 import typing
+import uuid
 
 import flask
 
@@ -109,8 +110,8 @@ def checked_get(
             raise ValueError('missing {!r}'.format(key))
 
     elif not isinstance(v, type(default)):
-        raise ValueError('invalid {!r}, expected {}, got {!r}'.format(
-            key, type(default).__name__, v,
+        raise ValueError('invalid {!r}, expected {}, got: {}'.format(
+            key, type(default).__name__, json.dumps(v),
         ))
 
     return v

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -93,13 +93,18 @@ def get_connector():
     return lora.Connector(**loraparams)
 
 
+K = typing.TypeVar('K', bound=typing.Hashable)
+V = typing.TypeVar('V')
+D = typing.Dict[K, V]
+
+
 def checked_get(
-    mapping: dict,
-    key: typing.Hashable,
-    default: typing.Hashable,
-    fallback: dict=None,
+    mapping: D,
+    key: K,
+    default: V,
+    fallback: D=None,
     required: bool=True,
-):
+) -> V:
     sentinel = object()
     v = mapping.get(key, sentinel)
 
@@ -108,6 +113,8 @@ def checked_get(
             return checked_get(fallback, key, default, None, required)
         elif required:
             raise ValueError('missing {!r}'.format(key))
+        else:
+            return default
 
     elif not isinstance(v, type(default)):
         raise ValueError('invalid {!r}, expected {}, got: {}'.format(
@@ -118,11 +125,11 @@ def checked_get(
 
 
 def get_uuid(
-    mapping: dict,
-    fallback: dict=None,
+    mapping: D,
+    fallback: D=None,
     *,
     key: typing.Hashable=keys.UUID
-):
+) -> str:
     v = checked_get(mapping, key, '', fallback=fallback)
 
     if not util.is_uuid(v):

--- a/mora/service/itsystem.py
+++ b/mora/service/itsystem.py
@@ -229,7 +229,7 @@ class ITSystems(common.AbstractRelationDetail):
         }
 
     def create(self, id, req):
-        systemobj = common.checked_get(req, keys.ITSYSTEM, {})
+        systemobj = common.checked_get(req, keys.ITSYSTEM, {}, required=True)
         systemid = common.get_uuid(systemobj)
 
         original = self.scope.get(

--- a/mora/service/orgunit.py
+++ b/mora/service/orgunit.py
@@ -475,7 +475,7 @@ def create_org_unit():
     org_unit_type_uuid = req.get(keys.ORG_UNIT_TYPE).get('uuid')
     addresses = [
         address.get_relation_for(addr[keys.ADDRESS_TYPE], addr[keys.VALUE])
-        for addr in req.get(keys.ADDRESSES) or []
+        for addr in common.checked_get(req, keys.ADDRESSES, [], required=False)
     ]
     valid_from = common.get_valid_from(req)
     valid_to = common.get_valid_to(req)

--- a/mora/service/orgunit.py
+++ b/mora/service/orgunit.py
@@ -475,7 +475,7 @@ def create_org_unit():
     org_unit_type_uuid = req.get(keys.ORG_UNIT_TYPE).get('uuid')
     addresses = [
         address.get_relation_for(addr[keys.ADDRESS_TYPE], addr[keys.VALUE])
-        for addr in common.checked_get(req, keys.ADDRESSES, [], required=False)
+        for addr in common.checked_get(req, keys.ADDRESSES, [])
     ]
     valid_from = common.get_valid_from(req)
     valid_to = common.get_valid_to(req)

--- a/tests/test_integration_itsystem.py
+++ b/tests/test_integration_itsystem.py
@@ -27,7 +27,7 @@ class Writing(util.LoRATestCase):
             '/service/e/{}/create'.format(userid),
             {
                 'message': (
-                    'invalid \'itsystem\', expected dict, got None'
+                    'invalid \'itsystem\', expected dict, got: null'
                 ),
                 'status': 400,
             },
@@ -69,7 +69,7 @@ class Writing(util.LoRATestCase):
             '/service/e/00000000-0000-0000-0000-000000000000/create',
             {
                 'message': (
-                    'invalid \'itsystem\', expected dict, got None'
+                    'invalid \'itsystem\', expected dict, got: null'
                 ),
                 'status': 400,
             },
@@ -240,7 +240,7 @@ class Writing(util.LoRATestCase):
         self.assertRequestResponse(
             '/service/e/{}/edit'.format(userid),
             {
-                'message': "invalid 'uuid', expected str, got None",
+                'message': "invalid 'uuid', expected str, got: null",
                 'status': 400,
             },
             json=[

--- a/tests/test_service_common.py
+++ b/tests/test_service_common.py
@@ -1897,3 +1897,62 @@ class TestClass(TestCase):
                 'uuid': 42,
             },
         )
+
+    def test_checked_get(self):
+        mapping = {
+            'list': [1337],
+            'dict': {1337: 1337},
+            'string': '1337',
+            'int': 1337,
+        }
+
+        # when it's there
+        self.assertIs(
+            common.checked_get(mapping, 'list', []),
+            mapping['list'],
+        )
+
+        self.assertIs(
+            common.checked_get(mapping, 'dict', {}),
+            mapping['dict'],
+        )
+
+        self.assertIs(
+            common.checked_get(mapping, 'string', ''),
+            mapping['string'],
+        )
+
+        self.assertIs(
+            common.checked_get(mapping, 'int', 1337),
+            mapping['int'],
+        )
+
+        # when it's not there
+        self.assertEqual(
+            common.checked_get(mapping, 'nonexistent', [], required=False),
+            [],
+        )
+
+        self.assertEqual(
+            common.checked_get(mapping, 'nonexistent', {}, required=False),
+            {},
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing 'nonexistent'"):
+            common.checked_get(mapping, 'nonexistent', [])
+
+        with self.assertRaisesRegex(ValueError, "missing 'nonexistent'"):
+            common.checked_get(mapping, 'nonexistent', {})
+
+        # bad value
+        with self.assertRaisesRegex(
+                ValueError,
+                'invalid \'dict\', expected list, got: {"1337": 1337}',
+        ):
+            common.checked_get(mapping, 'dict', [])
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"invalid 'list', expected dict, got: \[1337\]",
+        ):
+            common.checked_get(mapping, 'list', {})

--- a/tests/test_service_common.py
+++ b/tests/test_service_common.py
@@ -1929,20 +1929,20 @@ class TestClass(TestCase):
 
         # when it's not there
         self.assertEqual(
-            common.checked_get(mapping, 'nonexistent', [], required=False),
+            common.checked_get(mapping, 'nonexistent', []),
             [],
         )
 
         self.assertEqual(
-            common.checked_get(mapping, 'nonexistent', {}, required=False),
+            common.checked_get(mapping, 'nonexistent', {}),
             {},
         )
 
         with self.assertRaisesRegex(ValueError, "missing 'nonexistent'"):
-            common.checked_get(mapping, 'nonexistent', [])
+            common.checked_get(mapping, 'nonexistent', [], required=True)
 
         with self.assertRaisesRegex(ValueError, "missing 'nonexistent'"):
-            common.checked_get(mapping, 'nonexistent', {})
+            common.checked_get(mapping, 'nonexistent', {}, required=True)
 
         # bad value
         with self.assertRaisesRegex(


### PR DESCRIPTION
Add a bit of type checking to the `addresses` field in org. units. Novik ran into this.