### PR TITLE
cpr test: only return something for valid CPR numbers

### DIFF
--- a/mora/integrations/serviceplatformen.py
+++ b/mora/integrations/serviceplatformen.py
@@ -15,6 +15,9 @@ from .. import settings
 
 
 def get_citizen(cpr):
+    if not util.is_cpr_number(cpr):
+        raise ValueError('invalid CPR number!')
+
     if settings.PROD_MODE:
         try:
             # TBC when SP library is extracted from AVA repo
@@ -158,9 +161,6 @@ LAST_NAMES = [
 
 
 def _get_citizen_stub(cpr):
-    if not util.is_cpr_number(cpr):
-        return None
-
     # Seed random with CPR number to ensure consistent output
     random.seed(cpr)
 

--- a/mora/integrations/serviceplatformen.py
+++ b/mora/integrations/serviceplatformen.py
@@ -10,7 +10,8 @@ import random
 
 from requests import HTTPError
 
-from mora import settings
+from .. import util
+from .. import settings
 
 
 def get_citizen(cpr):
@@ -157,6 +158,9 @@ LAST_NAMES = [
 
 
 def _get_citizen_stub(cpr):
+    if not util.is_cpr_number(cpr):
+        return None
+
     # Seed random with CPR number to ensure consistent output
     random.seed(cpr)
 

--- a/mora/service/cpr.py
+++ b/mora/service/cpr.py
@@ -48,12 +48,20 @@ def search_cpr():
     """
     cpr = flask.request.args['q']
 
-    sp_data = get_citizen(cpr)
+    try:
+        sp_data = get_citizen(cpr)
+    except KeyError:
+        raise exceptions.NotFoundError(
+            'no such person found',
+            cpr=cpr,
+        )
+    except ValueError:
+        raise exceptions.ValidationError(
+            'not a valid cpr number',
+            cpr=cpr,
+        )
 
-    if sp_data:
-        return flask.jsonify(format_cpr_response(sp_data, cpr))
-    else:
-        return '', 404
+    return flask.jsonify(format_cpr_response(sp_data, cpr))
 
 
 def format_cpr_response(sp_data: dict, cpr: str):

--- a/mora/service/cpr.py
+++ b/mora/service/cpr.py
@@ -48,14 +48,12 @@ def search_cpr():
     """
     cpr = flask.request.args['q']
 
-    if len(cpr) != 10:
-        raise exceptions.ValidationError(
-            'CPR no. should be 10 characters long',
-        )
-
     sp_data = get_citizen(cpr)
 
-    return flask.jsonify(format_cpr_response(sp_data, cpr))
+    if sp_data:
+        return flask.jsonify(format_cpr_response(sp_data, cpr))
+    else:
+        return '', 404
 
 
 def format_cpr_response(sp_data: dict, cpr: str):

--- a/mora/util.py
+++ b/mora/util.py
@@ -279,12 +279,11 @@ def is_uuid(v):
         return False
 
 
-# TODO: more thorough checking?
-_cpr_re = re.compile(r'\d{10}')
-
-
 def is_cpr_number(v):
-    return isinstance(v, str) and _cpr_re.fullmatch(v)
+    try:
+        return v and bool(get_cpr_birthdate(v))
+    except ValueError:
+        return False
 
 
 def uniqueify(xs):

--- a/tests/test_cpr.py
+++ b/tests/test_cpr.py
@@ -1,0 +1,91 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+from unittest import mock
+
+import freezegun
+
+from . import util
+
+
+@freezegun.freeze_time('2017-01-01', tz_offset=1)
+@util.mock()
+class Tests(util.TestCase):
+    maxDiff = None
+
+    def test_cpr_lookup_prod_mode_false(self, m):
+        # Arrange
+        cpr = "0101501234"
+
+        expected = {
+            'name': 'Merle Mortensen',
+            'cpr_no': cpr
+        }
+
+        # Act
+        with util.override_settings(PROD_MODE=False):
+            self.assertRequestResponse(
+                '/service/e/cpr_lookup/?q={}'.format(cpr),
+                expected)
+
+            with mock.patch(
+                'mora.integrations.serviceplatformen._get_citizen_stub',
+                side_effect=KeyError('go away'),
+                assert_called_with='asdasdasdx',
+            ) as p:
+                self.assertRequestResponse(
+                    '/service/e/cpr_lookup/?q=1111111111',
+                    {
+                        'cause': 'not-found',
+                        'cpr': '1111111111',
+                        'description': 'no such person found',
+                        'error': True,
+                        'status': 404,
+                    },
+                    status_code=404,
+                )
+
+    def test_cpr_lookup_raises_on_wrong_length(self, m):
+        # Arrange
+
+        # Act
+        self.assertRequestResponse(
+            '/service/e/cpr_lookup/?q=1234/',
+            {
+                'cause': 'validation',
+                'cpr': '1234/',
+                'description': 'not a valid cpr number',
+                'error': True,
+                'status': 400,
+            },
+            status_code=400,
+        )
+
+        self.assertRequestResponse(
+            '/service/e/cpr_lookup/?q=1234567890123',
+            {
+                'cause': 'validation',
+                'cpr': '1234567890123',
+                'description': 'not a valid cpr number',
+                'error': True,
+                'status': 400,
+            },
+            status_code=400,
+        )
+
+        self.assertRequestResponse(
+            '/service/e/cpr_lookup/?q=2222222222',
+            {
+                'cause': 'validation',
+                'cpr': '2222222222',
+                'description': 'not a valid cpr number',
+                'error': True,
+                'status': 400,
+            },
+            status_code=400,
+        )

--- a/tests/test_integration_employee.py
+++ b/tests/test_integration_employee.py
@@ -129,6 +129,9 @@ class Tests(util.LoRATestCase):
         # Arrange
 
         # Act
-        self.assertRequestFails('/service/e/cpr_lookup/?q=1234/', 400)
+        self.assertRequestFails('/service/e/cpr_lookup/?q=1234/', 404)
         self.assertRequestFails('/service/e/cpr_lookup/?q=1234567890123/',
-                                400)
+                                404)
+
+        self.assertRequestFails('/service/e/cpr_lookup/?q=2222222222/',
+                                404)

--- a/tests/test_integration_employee.py
+++ b/tests/test_integration_employee.py
@@ -109,29 +109,3 @@ class Tests(util.LoRATestCase):
                 'uuid': userid,
             },
         )
-
-    def test_cpr_lookup_prod_mode_false(self):
-        # Arrange
-        cpr = "0101501234"
-
-        expected = {
-            'name': 'Merle Mortensen',
-            'cpr_no': cpr
-        }
-
-        # Act
-        with util.override_settings(PROD_MODE=False):
-            self.assertRequestResponse(
-                '/service/e/cpr_lookup/?q={}'.format(cpr),
-                expected)
-
-    def test_cpr_lookup_raises_on_wrong_length(self):
-        # Arrange
-
-        # Act
-        self.assertRequestFails('/service/e/cpr_lookup/?q=1234/', 404)
-        self.assertRequestFails('/service/e/cpr_lookup/?q=1234567890123/',
-                                404)
-
-        self.assertRequestFails('/service/e/cpr_lookup/?q=2222222222/',
-                                404)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,6 +144,7 @@ class TestUtils(TestCase):
 
     def test_is_cpr_number(self):
         self.assertTrue(util.is_cpr_number('0101011000'))
+        self.assertFalse(util.is_cpr_number('2222222222'))
         self.assertFalse(util.is_cpr_number('42'))
         self.assertFalse(util.is_cpr_number(None))
 


### PR DESCRIPTION
By 'valid' we mean the ones that represent a valid date of birth.