### PR TITLE
requirements: use just-released pyexcel-io v0.5.7

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,4 +13,3 @@ flake8-imports>=0.1.1
 flake8-module-name>=0.1.5
 flake8-mypy>=17.8.0
 notsouid>=0.0.3
--e git+https://github.com/magenta-aps/pyexcel-io.git@fix-dot-books#egg=pyexcel-io

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ sphinxcontrib-httpdomain>=1.6.0
 recommonmark>=0.4.0
 grequests~=0.3.0
 pyexcel>=0.5.7
+pyexcel-io>=0.5.7
 pyexcel-xlsx>=0.5.5
 pyexcel-ods>=0.5.2
 gevent~=1.2.2


### PR DESCRIPTION
The 0.5.7 release of pyexcel-io fixes loading CSV files from
directories containing '.' in their name, which was the motivation for
our fork.

See also <https://github.com/pyexcel/pyexcel-io/pull/47>.