### PR TITLE
frontend: always use midnight as the time-of-day for validity periods

### DIFF
--- a/src/components/atoms/MoDatePicker.vue
+++ b/src/components/atoms/MoDatePicker.vue
@@ -15,7 +15,7 @@
       <input 
         :name="nameId"
         :data-vv-as="label" 
-        v-model="selected"
+        v-model="date_string"
         type="hidden"
         v-validate="{required: required}">
 
@@ -51,6 +51,7 @@ export default {
         from: null
       },
       selected: null,
+      date_string: null,
       da: da
     }
   },
@@ -61,6 +62,12 @@ export default {
   },
   watch: {
     selected (newVal) {
+      // send on a date-only string in ISO format, so that we
+      // disregard timezones and the time-of-day
+      this.date_string = this.$moment(new Date(newVal)).format('YYYY-MM-DD')
+    },
+
+    date_string (newVal) {
       this.$emit('input', newVal)
     },
 


### PR DESCRIPTION
We simply use a ISO 8601 date, i.e. YYYY-MM-DD, without a timezone --
this ensures that we don't get any timezone-dependant logic.