### PR TITLE
lora: use proper moment for 'now', if possible, rather than today

### DIFF
--- a/mora/lora.py
+++ b/mora/lora.py
@@ -240,7 +240,6 @@ class Connector:
         self.now = util.parsedatetime(
             defaults.pop('effective_date', None) or util.now(),
         )
-        self.now = self.now.replace(microsecond=0)
 
         if self.__validity == 'past':
             self.start = util.NEGATIVE_INFINITY

--- a/mora/lora.py
+++ b/mora/lora.py
@@ -243,12 +243,12 @@ class Connector:
         self.now = self.now.replace(microsecond=0)
 
         if self.__validity == 'past':
-            self.start = util.negative_infinity
+            self.start = util.NEGATIVE_INFINITY
             self.end = self.now
 
         elif self.__validity == 'future':
             self.start = self.now
-            self.end = util.positive_infinity
+            self.end = util.POSITIVE_INFINITY
 
         elif self.__validity == 'present':
             # we should probably use 'virkningstid' but that means we
@@ -264,7 +264,7 @@ class Connector:
             if 'virkningtil' in defaults:
                 self.end = util.parsedatetime(defaults.pop('virkningtil'))
             else:
-                self.end = self.start + util.minimal_interval
+                self.end = self.start + util.MINIMAL_INTERVAL
 
         else:
             raise exceptions.HTTPException(

--- a/mora/service/address.py
+++ b/mora/service/address.py
@@ -364,8 +364,8 @@ class Addresses(common.AbstractRelationDetail):
                 convert(self.scope.get(id)),
                 key=(
                     lambda v: (
-                        common.get_valid_from(v) or util.negative_infinity,
-                        common.get_valid_to(v) or util.positive_infinity,
+                        common.get_valid_from(v) or util.NEGATIVE_INFINITY,
+                        common.get_valid_to(v) or util.POSITIVE_INFINITY,
                         str(v[keys.NAME]),
                     )
                 ),

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -669,7 +669,7 @@ def get_valid_to(obj, fallback=None) -> datetime.datetime:
         valid_to = validity.get(keys.TO, sentinel)
 
         if valid_to is None:
-            return util.positive_infinity
+            return util.POSITIVE_INFINITY
 
         elif valid_to is not sentinel:
             return util.from_iso_time(valid_to)
@@ -677,7 +677,7 @@ def get_valid_to(obj, fallback=None) -> datetime.datetime:
     if fallback is not None:
         return get_valid_to(fallback)
     else:
-        return util.positive_infinity
+        return util.POSITIVE_INFINITY
 
 
 def get_validities(obj, fallback=None):

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -81,10 +81,8 @@ FieldTuple = collections.namedtuple(
 )
 
 
-def get_connector():
+def get_connector(**loraparams):
     args = flask.request.args
-
-    loraparams = dict()
 
     if args.get('at'):
         loraparams['effective_date'] = util.from_iso_time(args['at'])

--- a/mora/service/details.py
+++ b/mora/service/details.py
@@ -71,15 +71,13 @@ def list_details(type, id):
     The value above informs you that at least one entry exists for each of
     'engagement' and 'leave' either in the past, present or future.
     '''
-    c = common.get_connector()
 
-    r = []
+    c = common.get_connector(virkningfra='-infinity',
+                             virkningtil='infinity')
 
     info = DETAIL_TYPES[type]
     search = {
         info.search: id,
-        'virkningfra': '-infinity',
-        'virkningtil': 'infinity',
     }
     scope = getattr(c, info.scope)
 
@@ -551,8 +549,6 @@ def get_detail(type, id, function):
                     'tilknyttedeorganisationer',
                 ),
             },
-            virkningfra='-infinity',
-            virkningtil='infinity',
         )
         if common.is_reg_valid(effect)
     ]

--- a/mora/service/employee.py
+++ b/mora/service/employee.py
@@ -1007,7 +1007,7 @@ def create_employee():
     try:
         valid_from = util.get_cpr_birthdate(cpr)
     except ValueError:
-        valid_from = util.negative_infinity
+        valid_from = util.NEGATIVE_INFINITY
 
     bruger = c.bruger.fetch(
         tilknyttedepersoner="urn:dk:cpr:person:{}".format(cpr),
@@ -1019,7 +1019,7 @@ def create_employee():
             cpr=cpr
         )
 
-    valid_to = util.positive_infinity
+    valid_to = util.POSITIVE_INFINITY
 
     # TODO: put something useful into the default user key
     bvn = common.checked_get(req, keys.USER_KEY, str(uuid.uuid4()))

--- a/mora/util.py
+++ b/mora/util.py
@@ -42,6 +42,8 @@ negative_infinity = datetime.datetime.min.replace(
         -datetime.timedelta(hours=23, minutes=59),
     ),
 )
+minimal_interval = datetime.timedelta(microseconds=1)
+
 
 # TODO: the default timezone should be configurable, shouldn't it?
 default_timezone = dateutil.tz.gettz('Europe/Copenhagen')
@@ -154,12 +156,6 @@ def to_frontend_time(s):
 def now() -> datetime.datetime:
     '''Get the current time, localized to the current time zone.'''
     return datetime.datetime.now().replace(tzinfo=default_timezone)
-
-
-def today() -> datetime.datetime:
-    '''Get midnight of current date, localized to the current time zone.'''
-    return datetime.datetime.combine(datetime.date.today(),
-                                     datetime.time(tzinfo=default_timezone))
 
 
 def restrictargs(*allowed: str, required: typing.Iterable[str]=[]):

--- a/mora/util.py
+++ b/mora/util.py
@@ -48,7 +48,7 @@ MINIMAL_INTERVAL = datetime.timedelta(microseconds=1)
 # TODO: the default timezone should be configurable, shouldn't it?
 DEFAULT_TIMEZONE = dateutil.tz.gettz('Europe/Copenhagen')
 
-tzinfos = {
+_tzinfos = {
     None: DEFAULT_TIMEZONE,
     0: dateutil.tz.tzutc,
     1 * 60**2: DEFAULT_TIMEZONE,
@@ -93,7 +93,7 @@ def parsedatetime(s: str) -> datetime.datetime:
         pass
 
     try:
-        dt = dateutil.parser.parse(s, dayfirst=True, tzinfos=tzinfos)
+        dt = dateutil.parser.parse(s, dayfirst=True, tzinfos=_tzinfos)
     except ValueError:
         raise exceptions.HTTPException('cannot parse {!r}'.format(s))
 

--- a/mora/util.py
+++ b/mora/util.py
@@ -30,29 +30,29 @@ from . import exceptions
 PLACEHOLDER = "\u2014"
 
 # timezone-aware versions of min/max
-positive_infinity = datetime.datetime.max.replace(
+POSITIVE_INFINITY = datetime.datetime.max.replace(
     tzinfo=dateutil.tz.tzoffset(
         'MAX',
         datetime.timedelta(hours=23, minutes=59),
     ),
 )
-negative_infinity = datetime.datetime.min.replace(
+NEGATIVE_INFINITY = datetime.datetime.min.replace(
     tzinfo=dateutil.tz.tzoffset(
         'MIN',
         -datetime.timedelta(hours=23, minutes=59),
     ),
 )
-minimal_interval = datetime.timedelta(microseconds=1)
+MINIMAL_INTERVAL = datetime.timedelta(microseconds=1)
 
 
 # TODO: the default timezone should be configurable, shouldn't it?
-default_timezone = dateutil.tz.gettz('Europe/Copenhagen')
+DEFAULT_TIMEZONE = dateutil.tz.gettz('Europe/Copenhagen')
 
 tzinfos = {
-    None: default_timezone,
+    None: DEFAULT_TIMEZONE,
     0: dateutil.tz.tzutc,
-    1 * 60**2: default_timezone,
-    2 * 60**2: default_timezone,
+    1 * 60**2: DEFAULT_TIMEZONE,
+    2 * 60**2: DEFAULT_TIMEZONE,
 }
 
 
@@ -64,7 +64,7 @@ def parsedatetime(s: str) -> datetime.datetime:
     if isinstance(s, datetime.date):
         dt = s
 
-        if dt in (positive_infinity, negative_infinity):
+        if dt in (POSITIVE_INFINITY, NEGATIVE_INFINITY):
             return dt
 
         if not isinstance(dt, datetime.datetime):
@@ -73,14 +73,14 @@ def parsedatetime(s: str) -> datetime.datetime:
             )
 
         if not dt.tzinfo:
-            dt = dt.replace(tzinfo=default_timezone)
+            dt = dt.replace(tzinfo=DEFAULT_TIMEZONE)
 
         return dt
 
     elif s == 'infinity':
-        return positive_infinity
+        return POSITIVE_INFINITY
     elif s == '-infinity':
-        return negative_infinity
+        return NEGATIVE_INFINITY
 
     if ' ' in s:
         # the frontend doesn't escape the 'plus' in ISO 8601 dates, so
@@ -107,9 +107,9 @@ def do_ranges_overlap(first_start, first_end, second_start, second_end):
 def to_lora_time(s):
     dt = parsedatetime(s)
 
-    if dt == positive_infinity:
+    if dt == POSITIVE_INFINITY:
         return 'infinity'
-    elif dt == negative_infinity:
+    elif dt == NEGATIVE_INFINITY:
         return '-infinity'
     else:
         return dt.isoformat()
@@ -125,8 +125,8 @@ def to_iso_time(s):
     dt = parsedatetime(s)
 
     return (
-        dt.astimezone(default_timezone).isoformat()
-        if dt not in (positive_infinity, negative_infinity)
+        dt.astimezone(DEFAULT_TIMEZONE).isoformat()
+        if dt not in (POSITIVE_INFINITY, NEGATIVE_INFINITY)
         else None
     )
 
@@ -135,7 +135,7 @@ def from_iso_time(s):
     dt = dateutil.parser.isoparse(s)
 
     if not dt.tzinfo:
-        dt = dt.replace(tzinfo=default_timezone)
+        dt = dt.replace(tzinfo=DEFAULT_TIMEZONE)
 
     return dt
 
@@ -143,9 +143,9 @@ def from_iso_time(s):
 def to_frontend_time(s):
     dt = parsedatetime(s)
 
-    if dt == positive_infinity:
+    if dt == POSITIVE_INFINITY:
         return 'infinity'
-    elif dt == negative_infinity:
+    elif dt == NEGATIVE_INFINITY:
         return '-infinity'
     elif dt and dt.time().replace(tzinfo=None) == datetime.time():
         return unparsedate(dt.date())
@@ -155,7 +155,7 @@ def to_frontend_time(s):
 
 def now() -> datetime.datetime:
     '''Get the current time, localized to the current time zone.'''
-    return datetime.datetime.now().replace(tzinfo=default_timezone)
+    return datetime.datetime.now().replace(tzinfo=DEFAULT_TIMEZONE)
 
 
 def restrictargs(*allowed: str, required: typing.Iterable[str]=[]):
@@ -335,7 +335,7 @@ def get_cpr_birthdate(number: typing.Union[int, str]) -> datetime.datetime:
 
     try:
         return datetime.datetime(century + year, month, day,
-                                 tzinfo=default_timezone)
+                                 tzinfo=DEFAULT_TIMEZONE)
     except ValueError:
         raise ValueError('invalid CPR number {}'.format(number))
 

--- a/tests/mocking/invalid-itsystem.json
+++ b/tests/mocking/invalid-itsystem.json
@@ -1,5 +1,5 @@
 {
-  "http://mox/organisation/bruger?virkningtil=2018-03-21T00%3A00%3A00%2B01%3A00&virkningfra=2018-03-20T00%3A00%3A00%2B01%3A00&uuid=34705881-8af9-4254-ac3f-31738eae0be8": {
+  "http://mox/organisation/bruger?virkningtil=2018-03-20T00%3A00%3A00.000001%2B01%3A00&virkningfra=2018-03-20T00%3A00%3A00%2B01%3A00&uuid=34705881-8af9-4254-ac3f-31738eae0be8": {
     "results": [
       [
         {
@@ -169,7 +169,7 @@
       ]
     ]
   },
-  "http://mox/organisation/itsystem?uuid=a7ecd46a-9d70-4170-bde9-9bf44cf8632b&virkningfra=2018-03-20T00%3A00%3A00%2B01%3A00&virkningtil=2018-03-21T00%3A00%3A00%2B01%3A00": {
+  "http://mox/organisation/itsystem?uuid=a7ecd46a-9d70-4170-bde9-9bf44cf8632b&virkningfra=2018-03-20T00%3A00%3A00%2B01%3A00&virkningtil=2018-03-20T00%3A00%3A00.000001%2B01%3A00": {
     "results": [
       [
         {
@@ -242,7 +242,7 @@
       ]
     ]
   },
-  "http://mox/organisation/itsystem?virkningfra=2018-03-20T00%3A00%3A00%2B01%3A00&uuid=990255f7-44c7-4fec-9ef8-27fe73763afd&virkningtil=2018-03-21T00%3A00%3A00%2B01%3A00": {
+  "http://mox/organisation/itsystem?virkningfra=2018-03-20T00%3A00%3A00%2B01%3A00&uuid=990255f7-44c7-4fec-9ef8-27fe73763afd&virkningtil=2018-03-20T00%3A00%3A00.000001%2B01%3A00": {
     "results": [
       [
         {

--- a/tests/mocking/reading-organisation.json
+++ b/tests/mocking/reading-organisation.json
@@ -1,12 +1,12 @@
 {
-  "http://mox/organisation/organisation?bvn=%25&virkningtil=2017-07-29T00%3A00%3A00%2B02%3A00&virkningfra=2017-07-28T00%3A00%3A00%2B02%3A00": {
+  "http://mox/organisation/organisation?bvn=%25&virkningtil=2017-07-29T00%3A00%3A00%2B02%3A00&virkningfra=2017-07-27T00%3A00%3A00.000001%2B02%3A00": {
     "results": [
       [
         "456362c4-0ee4-4e5e-a72c-751239745e62"
       ]
     ]
   },
-  "http://mox/organisation/organisation?uuid=456362c4-0ee4-4e5e-a72c-751239745e62&virkningfra=2017-07-28T00%3A00%3A00%2B02%3A00&virkningtil=2017-07-29T00%3A00%3A00%2B02%3A00": {
+  "http://mox/organisation/organisation?uuid=456362c4-0ee4-4e5e-a72c-751239745e62&virkningfra=2017-07-28T00%3A00%3A00%2B02%3A00&virkningtil=2017-07-28T00%3A00%3A00.000001%2B02%3A00": {
     "results": [
       [
         {
@@ -66,120 +66,6 @@
             }
           ]
         }
-      ]
-    ]
-  },
-  "http://mox/organisation/organisationenhed?uuid=2874e1dc-85e6-4269-823a-e1125484dfd3&virkningfra=2017-07-28T00%3A00%3A00%2B02%3A00&virkningtil=2017-07-29T00%3A00%3A00%2B02%3A00": {
-    "results": [
-      [
-        {
-          "id": "2874e1dc-85e6-4269-823a-e1125484dfd3",
-          "registreringer": [
-            {
-              "attributter": {
-                "organisationenhedegenskaber": [
-                  {
-                    "brugervendtnoegle": "root",
-                    "enhedsnavn": "Overordnet Enhed",
-                    "virkning": {
-                      "from": "2016-01-01 00:00:00+01",
-                      "from_included": true,
-                      "to": "infinity",
-                      "to_included": false
-                    }
-                  }
-                ]
-              },
-              "brugerref": "42c432e8-9c4a-11e6-9f62-873cf34a735f",
-              "fratidspunkt": {
-                "graenseindikator": true,
-                "tidsstempeldatotid": "2017-08-17T10:27:27.702649+02:00"
-              },
-              "livscykluskode": "Importeret",
-              "note": "Automatisk indlæsning",
-              "relationer": {
-                "adresser": [
-                  {
-                    "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
-                    "objekttype": "v0:1:Kontor",
-                    "virkning": {
-                      "from": "2016-01-01 00:00:00+01",
-                      "from_included": true,
-                      "to": "infinity",
-                      "to_included": false
-                    }
-                  },
-                  {
-                    "urn": "urn:magenta.dk:telefon:+4587150000",
-                    "objekttype": "v0:external:b1f1817d-5f02-4331-b8b3-97330a5d3197",
-                    "virkning": {
-                      "from": "2016-01-01 00:00:00+01",
-                      "from_included": true,
-                      "to": "infinity",
-                      "to_included": false
-                    }
-                  }
-                ],
-                "enhedstype": [
-                  {
-                    "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
-                    "virkning": {
-                      "from": "2016-01-01 00:00:00+01",
-                      "from_included": true,
-                      "to": "infinity",
-                      "to_included": false
-                    }
-                  }
-                ],
-                "overordnet": [
-                  {
-                    "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
-                    "virkning": {
-                      "from": "2016-01-01 00:00:00+01",
-                      "from_included": true,
-                      "to": "infinity",
-                      "to_included": false
-                    }
-                  }
-                ],
-                "tilhoerer": [
-                  {
-                    "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
-                    "virkning": {
-                      "from": "2016-01-01 00:00:00+01",
-                      "from_included": true,
-                      "to": "infinity",
-                      "to_included": false
-                    }
-                  }
-                ]
-              },
-              "tilstande": {
-                "organisationenhedgyldighed": [
-                  {
-                    "gyldighed": "Aktiv",
-                    "virkning": {
-                      "from": "2016-01-01 00:00:00+01",
-                      "from_included": true,
-                      "to": "infinity",
-                      "to_included": false
-                    }
-                  }
-                ]
-              },
-              "tiltidspunkt": {
-                "tidsstempeldatotid": "infinity"
-              }
-            }
-          ]
-        }
-      ]
-    ]
-  },
-  "http://mox/organisation/organisationenhed?virkningfra=2017-07-28T00%3A00%3A00%2B02%3A00&overordnet=456362c4-0ee4-4e5e-a72c-751239745e62&virkningtil=2017-07-29T00%3A00%3A00%2B02%3A00": {
-    "results": [
-      [
-        "2874e1dc-85e6-4269-823a-e1125484dfd3"
       ]
     ]
   }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -18,7 +18,7 @@ ORG_URL = (
     'http://mox/organisation/organisation'
     '?bvn=%25'
     '&virkningfra=2001-01-01T00%3A00%3A00%2B01%3A00'
-    '&virkningtil=2001-01-02T00%3A00%3A00%2B01%3A00'
+    '&virkningtil=2001-01-01T00%3A00%3A00.000001%2B01%3A00'
 )
 
 

--- a/tests/test_integration_address.py
+++ b/tests/test_integration_address.py
@@ -1751,10 +1751,17 @@ class Writing(util.LoRATestCase):
             c.organisationenhed.get(unitid)['relationer']['adresser'],
         )
 
+        # it's in the future, so not written yet
         self.assertRequestResponse(
             '/service/ou/{}/details/address'.format(unitid),
-            addresses,
+            addresses[:-1],
         )
+
+        with freezegun.freeze_time('2017-01-02', tz_offset=1):
+            self.assertRequestResponse(
+                '/service/ou/{}/details/address'.format(unitid),
+                addresses,
+            )
 
     def test_edit_org_unit_address_overwrite(self, mock):
         self.load_sample_structures()

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -17,7 +17,7 @@ from . import util
 
 
 @util.mock()
-@freezegun.freeze_time('2010-06-01')
+@freezegun.freeze_time('2010-06-01', tz_offset=2)
 class Tests(util.TestCase):
     def test_get_date_chunks(self, m):
         def check(validity, dates, expected):
@@ -42,10 +42,13 @@ class Tests(util.TestCase):
             '2011-01-01',
         ]
 
+        with self.subTest('prerequisite'):
+            self.assertEqual('2010-06-01T02:00:00+02:00',
+                             mora_util.now().isoformat())
+
         with self.subTest('present I'):
             check('present', dates, [
                 ('2010-06-01T00:00:00+02:00', '2010-06-01T12:00:00+02:00'),
-                ('2010-06-01T12:00:00+02:00', '2010-06-02T00:00:00+02:00'),
             ])
 
         with self.subTest('past I'):
@@ -56,6 +59,7 @@ class Tests(util.TestCase):
 
         with self.subTest('future I'):
             check('future', dates, [
+                ('2010-06-01T12:00:00+02:00', '2010-06-02T00:00:00+02:00'),
                 ('2010-06-02T00:00:00+02:00', '2010-06-03T00:00:00+02:00'),
                 ('2010-06-03T00:00:00+02:00', '2011-01-01T00:00:00+01:00'),
             ])
@@ -95,7 +99,7 @@ class Tests(util.TestCase):
         URL = (
             settings.LORA_URL + 'organisation/organisationenhed?'
             'uuid=00000000-0000-0000-0000-000000000000'
-            '&virkningfra=2010-06-02T00%3A00%3A00%2B02%3A00'
+            '&virkningfra=2010-06-01T02%3A00%3A00%2B02%3A00'
             '&virkningtil=infinity'
         )
         m.get(

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -26,7 +26,7 @@ class SimpleTests(unittest.TestCase):
         URL = (
             settings.LORA_URL + 'organisation/organisationenhed?'
             'uuid=00000000-0000-0000-0000-000000000000'
-            '&virkningfra=2001-01-02T00%3A00%3A00%2B01%3A00'
+            '&virkningfra=2001-01-01T01%3A00%3A00%2B01%3A00'
             '&virkningtil=infinity'
         )
         m.get(

--- a/tests/test_service_address.py
+++ b/tests/test_service_address.py
@@ -19,7 +19,7 @@ class TestAddressLookup(util.TestCase):
             'http://mox/organisation/organisation'
             '?uuid=00000000-0000-0000-0000-000000000000'
             '&virkningfra=2016-06-06T00%3A00%3A00%2B02%3A00'
-            '&virkningtil=2016-06-07T00%3A00%3A00%2B02%3A00',
+            '&virkningtil=2016-06-06T00%3A00%3A00.000001%2B02%3A00',
             json={
                 "results": [
                     [{
@@ -67,7 +67,7 @@ class TestAddressLookup(util.TestCase):
             'http://mox/organisation/organisation'
             '?uuid=00000000-0000-0000-0000-000000000000'
             '&virkningfra=2016-06-06T00%3A00%3A00%2B02%3A00'
-            '&virkningtil=2016-06-07T00%3A00%3A00%2B02%3A00',
+            '&virkningtil=2016-06-06T00%3A00%3A00.000001%2B02%3A00',
             json={
                 "results": [
                     [{
@@ -122,7 +122,7 @@ class TestAddressLookup(util.TestCase):
             'http://mox/organisation/organisation'
             '?uuid=456362c4-0ee4-4e5e-a72c-751239745e62'
             '&virkningfra=2016-06-06T00%3A00%3A00%2B02%3A00'
-            '&virkningtil=2016-06-07T00%3A00%3A00%2B02%3A00',
+            '&virkningtil=2016-06-06T00%3A00%3A00.000001%2B02%3A00',
             json={
                 "results": [
                     [{

--- a/tests/test_service_common.py
+++ b/tests/test_service_common.py
@@ -1743,7 +1743,7 @@ class TestClass(TestCase):
         ))
 
         self.assertEqual(
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
             common.get_valid_to({}),
         )
 
@@ -1751,11 +1751,11 @@ class TestClass(TestCase):
             common.get_valid_to({
                 'validity': {},
             }),
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
         )
 
         self.assertEqual(
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
             common.get_valid_to(
                 {},
                 {
@@ -1766,7 +1766,7 @@ class TestClass(TestCase):
         )
 
         self.assertEqual(
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
             common.get_valid_to(
                 {
                     'validity': {
@@ -1777,7 +1777,7 @@ class TestClass(TestCase):
         )
 
         self.assertEqual(
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
             common.get_valid_to(
                 {},
                 {
@@ -1814,18 +1814,18 @@ class TestClass(TestCase):
         # still nothing
         self.assertEqual(
             common.get_valid_to({}, {}),
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
         )
 
         self.assertEqual(
             common.get_valid_to({}, {
                 'validity': None,
             }),
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
         )
 
         self.assertEqual(
-            util.positive_infinity,
+            util.POSITIVE_INFINITY,
             common.get_valid_to({}, {
                 'validity': {
                     'to': None,
@@ -1835,7 +1835,7 @@ class TestClass(TestCase):
 
         # actually set
         self.assertEqual(
-            datetime.datetime(2018, 3, 5, tzinfo=util.default_timezone),
+            datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
             common.get_valid_from({
                 'validity': {
                     'from': '2018-03-05',
@@ -1844,7 +1844,7 @@ class TestClass(TestCase):
         )
 
         self.assertEqual(
-            datetime.datetime(2018, 3, 5, tzinfo=util.default_timezone),
+            datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
             common.get_valid_to({
                 'validity': {
                     'to': '2018-03-05',
@@ -1854,7 +1854,7 @@ class TestClass(TestCase):
 
         # actually set in the fallback
         self.assertEqual(
-            datetime.datetime(2018, 3, 5, tzinfo=util.default_timezone),
+            datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
             common.get_valid_from({}, {
                 'validity': {
                     'from': '2018-03-05',
@@ -1863,7 +1863,7 @@ class TestClass(TestCase):
         )
 
         self.assertEqual(
-            datetime.datetime(2018, 3, 5, tzinfo=util.default_timezone),
+            datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
             common.get_valid_to({}, {
                 'validity': {
                     'to': '2018-03-05',
@@ -1872,8 +1872,8 @@ class TestClass(TestCase):
         )
 
         self.assertEqual(
-            (datetime.datetime(2018, 3, 5, tzinfo=util.default_timezone),
-             datetime.datetime(2018, 4, 5, tzinfo=util.default_timezone)),
+            (datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
+             datetime.datetime(2018, 4, 5, tzinfo=util.DEFAULT_TIMEZONE)),
             common.get_validities({
                 'validity': {
                     'from': '2018-03-05',
@@ -1883,8 +1883,8 @@ class TestClass(TestCase):
         )
 
         self.assertEqual(
-            (datetime.datetime(2018, 3, 5, tzinfo=util.default_timezone),
-             util.positive_infinity),
+            (datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
+             util.POSITIVE_INFINITY),
             common.get_validities({
                 'validity': {
                     'from': '2018-03-05'

--- a/tests/test_service_itsystem.py
+++ b/tests/test_service_itsystem.py
@@ -29,22 +29,6 @@ class TestInvalidItSystem(util.TestCase):
                     },
                 },
                 {
-                    'name': 'Lokal Rammearkitektur',
-                    'user_name': 'Sune Skriver',
-                    'uuid': '990255f7-44c7-4fec-9ef8-27fe73763afd',
-                    'validity': {
-                        'from': '2018-03-05T08:47:00+01:00', 'to': None,
-                    },
-                },
-                {
-                    'name': 'Active Directory',
-                    'user_name': 'Sune Skriver',
-                    'uuid': 'a7ecd46a-9d70-4170-bde9-9bf44cf8632b',
-                    'validity': {
-                        'from': '2018-03-14T08:58:00+01:00', 'to': None,
-                    },
-                },
-                {
                     'name': 'Active Directory',
                     'user_name': 'Sune Skriver',
                     'uuid': 'a7ecd46a-9d70-4170-bde9-9bf44cf8632b',
@@ -58,22 +42,6 @@ class TestInvalidItSystem(util.TestCase):
                     'uuid': '990255f7-44c7-4fec-9ef8-27fe73763afd',
                     'validity': {
                         'from': '2018-03-19T08:57:00+01:00', 'to': None,
-                    },
-                },
-                {
-                    'name': 'Lokal Rammearkitektur',
-                    'user_name': 'Sune Skriver',
-                    'uuid': '990255f7-44c7-4fec-9ef8-27fe73763afd',
-                    'validity': {
-                        'from': '2018-03-19T08:57:00+01:00', 'to': None,
-                    },
-                },
-                {
-                    'name': 'Lokal Rammearkitektur',
-                    'user_name': 'Sune Skriver',
-                    'uuid': '990255f7-44c7-4fec-9ef8-27fe73763afd',
-                    'validity': {
-                        'from': '2018-03-19T09:21:00+01:00', 'to': None,
                     },
                 },
                 {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,11 +77,11 @@ class TestUtils(TestCase):
                               '1999-15-11 00:00:00+01')
 
         # make sure we can round-trip the edge cases correctly
-        self.assertEqual(util.parsedatetime(util.negative_infinity),
-                         util.negative_infinity)
+        self.assertEqual(util.parsedatetime(util.NEGATIVE_INFINITY),
+                         util.NEGATIVE_INFINITY)
 
-        self.assertEqual(util.parsedatetime(util.positive_infinity),
-                         util.positive_infinity)
+        self.assertEqual(util.parsedatetime(util.POSITIVE_INFINITY),
+                         util.POSITIVE_INFINITY)
 
     def test_to_frontend_time(self):
         self.assertEqual(util.to_frontend_time(self.today), '01-06-2015')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,13 +20,20 @@ from .util import TestCase
 
 @freezegun.freeze_time('2015-06-01T01:10')
 class TestUtils(TestCase):
+    @property
+    def now(self):
+        return util.now()
+
+    @property
+    def today(self):
+        return util.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
     def test_to_lora_time(self):
         tests = {
-            util.today():
+            self.today:
             '2015-06-01T00:00:00+02:00',
 
-            util.now():
+            self.now:
             '2015-06-01T01:10:00+02:00',
 
             '01-06-2017':
@@ -77,8 +84,7 @@ class TestUtils(TestCase):
                          util.positive_infinity)
 
     def test_to_frontend_time(self):
-        self.assertEqual(util.to_frontend_time(util.today()),
-                         '01-06-2015')
+        self.assertEqual(util.to_frontend_time(self.today), '01-06-2015')
 
         self.assertEqual(util.to_frontend_time('2017-12-31 00:00:00+01'),
                          '31-12-2017')
@@ -103,9 +109,9 @@ class TestUtils(TestCase):
         self.assertEqual('01-06-2015',
                          util.to_frontend_time(datetime.date.today()))
         self.assertEqual('01-06-2015',
-                         util.to_frontend_time(util.today()))
+                         util.to_frontend_time(self.today))
         self.assertEqual('2015-06-01T01:10:00+02:00',
-                         util.to_frontend_time(util.now()))
+                         util.to_frontend_time(self.now))
         self.assertEqual('01-01-2015',
                          util.to_frontend_time(datetime.date(2015, 1, 1)))
         self.assertEqual('01-06-2015',

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -30,8 +30,8 @@ class TestIsDateRangeValid(unittest.TestCase):
         URL = (
             settings.LORA_URL + 'organisation/organisationenhed?'
             'uuid=00000000-0000-0000-0000-000000000000'
-            '&virkningfra=2000-01-01'
-            '&virkningtil=3000-01-01'
+            '&virkningfra=2000-01-01T00%3A00%3A00%2B01%3A00'
+            '&virkningtil=3000-01-01T00%3A00%3A00%2B01%3A00'
         )
 
         c = lora.Connector(virkningfra='2000-01-01',


### PR DESCRIPTION
This should properly remove the duplicates that we've run into, and
ensure that we only ever display entries that are properly current.

Ideally, we'd use the 'virkningstid' parameter to LoRA for this.
Unfortunately, the current code assumes that overriding 'virkningfra'
and 'virkningtil' in get() and fetch() work quite well. I fixed a few
issues, but the remaining ones were sufficiently annoying that I
simply opted for using a very small interval of one microsecond --
just like LoRA does, in fact.