### PR TITLE
#23054 employee engagements atomicity

### DIFF
--- a/mora/service/address.py
+++ b/mora/service/address.py
@@ -397,6 +397,10 @@ class Addresses(common.AbstractRelationDetail):
 
         self.scope.update(payload, id)
 
+    @staticmethod
+    def get_relation_for(req):
+        return 'adresser', get_relation_for(req)
+
     def edit(self, id, req):
         original = self.scope.get(
             uuid=id,

--- a/mora/service/association.py
+++ b/mora/service/association.py
@@ -52,7 +52,7 @@ def create_association(employee_uuid, req):
                                                       org_unit_uuid,
                                                       valid_from)
 
-    association = create_organisationsfunktion_payload(
+    return create_organisationsfunktion_payload(
         funktionsnavn=keys.ASSOCIATION_KEY,
         valid_from=valid_from,
         valid_to=valid_to,
@@ -66,8 +66,6 @@ def create_association(employee_uuid, req):
             address.get_relation_for(address_obj),
         ] if address_obj else None,
     )
-
-    c.organisationfunktion.create(association)
 
 
 def edit_association(employee_uuid, req):

--- a/mora/service/employee.py
+++ b/mora/service/employee.py
@@ -15,6 +15,7 @@ This section describes how to interact with employees.
 
 '''
 
+import collections
 import uuid
 
 import flask
@@ -442,9 +443,17 @@ def create_employee_relation(employee_uuid):
     }
 
     reqs = flask.request.get_json()
+    c = common.get_connector()
+
+    functions = []
+    rels = collections.defaultdict(list)
+    types = []
+
     for req in reqs:
         role_type = req.get('type')
         handler = handlers.get(role_type)
+
+        types.append(common.RELATION_TRANSLATIONS[role_type])
 
         if not handler:
             raise exceptions.HTTPException(
@@ -452,19 +461,43 @@ def create_employee_relation(employee_uuid):
                 message=role_type)
 
         elif issubclass(handler, common.AbstractRelationDetail):
-            handler(common.get_connector().bruger).create(
-                str(employee_uuid),
-                req,
-            )
+            relname, rel = handler.get_relation_for(req)
+
+            rels[relname].append(rel)
 
         else:
-            handler(str(employee_uuid), req)
+            functions.append(handler(str(employee_uuid), req))
 
+    note = "Opret {}".format(', '.join(types))
+
+    if not rels:
         # Write a noop entry to the user, to be used for the history
         common.add_bruger_history_entry(
             employee_uuid,
-            "Opret {}".format(common.RELATION_TRANSLATIONS[role_type])
+            note,
         )
+    else:
+        original = c.bruger.get(uuid=employee_uuid,
+                                virkningfra='-infinity',
+                                virkningtil='infinity')
+
+        if original is None:
+            raise exceptions.HTTPException(
+                exceptions.ErrorCodes.E_USER_NOT_FOUND,
+            )
+
+        payload = {
+            'relationer': {
+                relname: original['relationer'].get(relname, []) + relvalues
+                for relname, relvalues in rels.items()
+            },
+            'note': note,
+        }
+
+        c.bruger.update(payload, employee_uuid)
+
+    for payload in functions:
+        c.organisationfunktion.create(payload)
 
     # TODO:
     return flask.jsonify(employee_uuid), 200

--- a/mora/service/engagement.py
+++ b/mora/service/engagement.py
@@ -42,7 +42,8 @@ def create_engagement(employee_uuid, req):
                                               valid_to)
     validator.is_date_range_in_employee_range(employee_uuid, valid_from,
                                               valid_to)
-    engagement = create_organisationsfunktion_payload(
+
+    return create_organisationsfunktion_payload(
         funktionsnavn=keys.ENGAGEMENT_KEY,
         valid_from=valid_from,
         valid_to=valid_to,
@@ -53,8 +54,6 @@ def create_engagement(employee_uuid, req):
         funktionstype=engagement_type_uuid,
         opgaver=[{'uuid': job_function_uuid}] if job_function_uuid else []
     )
-
-    c.organisationfunktion.create(engagement)
 
 
 def edit_engagement(employee_uuid, req):

--- a/mora/service/leave.py
+++ b/mora/service/leave.py
@@ -44,7 +44,7 @@ def create_leave(employee_uuid, req):
     validator.does_employee_have_active_engagement(employee_uuid, valid_from,
                                                    valid_to)
 
-    leave = create_organisationsfunktion_payload(
+    return create_organisationsfunktion_payload(
         funktionsnavn=keys.LEAVE_KEY,
         valid_from=valid_from,
         valid_to=valid_to,
@@ -53,8 +53,6 @@ def create_leave(employee_uuid, req):
         tilknyttedeorganisationer=[org_uuid],
         funktionstype=leave_type_uuid,
     )
-
-    c.organisationfunktion.create(leave)
 
 
 def edit_leave(employee_uuid, req):

--- a/mora/service/manager.py
+++ b/mora/service/manager.py
@@ -64,7 +64,7 @@ def create_manager(employee_uuid, req):
     validator.is_date_range_in_employee_range(employee_uuid, valid_from,
                                               valid_to)
 
-    manager = common.create_organisationsfunktion_payload(
+    return common.create_organisationsfunktion_payload(
         funktionsnavn=keys.MANAGER_KEY,
         valid_from=valid_from,
         valid_to=valid_to,
@@ -78,8 +78,6 @@ def create_manager(employee_uuid, req):
             address.get_relation_for(address_obj),
         ] if address_obj else None,
     )
-
-    c.organisationfunktion.create(manager)
 
 
 def edit_manager(employee_uuid, req):

--- a/mora/service/role.py
+++ b/mora/service/role.py
@@ -45,7 +45,7 @@ def create_role(employee_uuid, req):
     validator.is_date_range_in_employee_range(employee_uuid, valid_from,
                                               valid_to)
 
-    role = create_organisationsfunktion_payload(
+    return create_organisationsfunktion_payload(
         funktionsnavn=keys.ROLE_KEY,
         valid_from=valid_from,
         valid_to=valid_to,
@@ -55,8 +55,6 @@ def create_role(employee_uuid, req):
         tilknyttedeenheder=[org_unit_uuid],
         funktionstype=role_type_uuid,
     )
-
-    c.organisationfunktion.create(role)
 
 
 def edit_role(employee_uuid, req):

--- a/tests/test_integration_address.py
+++ b/tests/test_integration_address.py
@@ -181,9 +181,6 @@ class Writing(util.LoRATestCase):
 
         self.assertNotEqual(original, edited)
 
-        # XXX: Remove 'garbage' value placed as part of create operation
-        del edited['tilstande']['brugergyldighed'][0]['virkning']['notetekst']
-
         self.assertEqual(original['attributter'], edited['attributter'])
         self.assertEqual(original['tilstande'], edited['tilstande'])
 

--- a/tests/test_integration_history.py
+++ b/tests/test_integration_history.py
@@ -157,27 +157,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
                 'user_ref': '42c432e8-9c4a-11e6-9f62-873cf34a735f'
             },
             {
-                'action': 'Opret leder',
-                'life_cycle_code': 'Rettet',
-                'user_ref': '42c432e8-9c4a-11e6-9f62-873cf34a735f'
-            },
-            {
-                'action': 'Opret orlov',
-                'life_cycle_code': 'Rettet',
-                'user_ref': '42c432e8-9c4a-11e6-9f62-873cf34a735f'
-            },
-            {
-                'action': 'Opret rolle',
-                'life_cycle_code': 'Rettet',
-                'user_ref': '42c432e8-9c4a-11e6-9f62-873cf34a735f'
-            },
-            {
-                'action': 'Opret tilknytning',
-                'life_cycle_code': 'Rettet',
-                'user_ref': '42c432e8-9c4a-11e6-9f62-873cf34a735f'
-            },
-            {
-                'action': 'Opret engagement',
+                'action': 'Opret engagement, tilknytning, rolle, orlov, leder',
                 'life_cycle_code': 'Rettet',
                 'user_ref': '42c432e8-9c4a-11e6-9f62-873cf34a735f'
             },

--- a/tests/test_integration_itsystem.py
+++ b/tests/test_integration_itsystem.py
@@ -160,7 +160,14 @@ class Writing(util.LoRATestCase):
                 'description': "Missing uuid",
                 'key': 'uuid',
                 'status': 400,
-                'obj': {}
+                'obj': {
+                    'itsystem': {},
+                    'type': 'it',
+                    'validity': {
+                        'from': None,
+                        'to': None,
+                    },
+                },
             },
             json=[
                 {
@@ -438,9 +445,6 @@ class Writing(util.LoRATestCase):
 
         self.assertNotEqual(original, edited)
 
-        # XXX: Remove 'garbage' value placed as part of create operation
-        del edited['tilstande']['brugergyldighed'][0]['virkning']['notetekst']
-
         self.assertEqual(original['attributter'], edited['attributter'])
         self.assertEqual(original['tilstande'], edited['tilstande'])
 
@@ -502,9 +506,6 @@ class Writing(util.LoRATestCase):
         )
 
         edited = c.bruger.get(userid)
-
-        # XXX: Remove 'garbage' value placed as part of create operation
-        del edited['tilstande']['brugergyldighed'][0]['virkning']['notetekst']
 
         self.assertEqual(original['attributter'], edited['attributter'])
         self.assertEqual(original['tilstande'], edited['tilstande'])


### PR DESCRIPTION
This change makes creation of details atomic, such that either all of
them succeed or all fail. Within reason, that is: this only applies to
validation, and won't handle, say, LoRA dying in the middle of a
request gracefully.