### PR TITLE
include validity when returning organisational units

### DIFF
--- a/mora/service/orgunit.py
+++ b/mora/service/orgunit.py
@@ -184,6 +184,7 @@ def get_one_orgunit(c, unitid, unit=None,
 
     attrs = unit['attributter']['organisationenhedegenskaber'][0]
     rels = unit['relationer']
+    validities = unit['tilstande']['organisationenhedgyldighed']
 
     r = {
         'name': attrs['enhedsnavn'],
@@ -223,8 +224,7 @@ def get_one_orgunit(c, unitid, unit=None,
             'invalid details {!r}'.format(details),
         )
 
-    if validity is not None:
-        r[keys.VALIDITY] = validity
+    r[keys.VALIDITY] = validity or common.get_effect_validity(validities[0])
 
     return r
 
@@ -244,6 +244,7 @@ def get_children(type, parentid):
 
     :<jsonarr string name: Human-readable name of the unit.
     :<jsonarr string user_key: Short, unique key identifying the unit.
+    :<jsonarr object validity: Validity range of the organisational unit.
     :<jsonarr uuid uuid: Machine-friendly UUID of the unit.
     :<jsonarr int child_count: Number of org. units nested immediately beneath
                                the organisation.
@@ -318,7 +319,7 @@ def get_orgunit(unitid):
       {
         "name": "Afdeling for Fortidshistorik",
         "user_key": "frem",
-        "uuid": "04c78fc2-72d2-4d02-b55f-807af19eac48"
+        "uuid": "04c78fc2-72d2-4d02-b55f-807af19eac48",
         "org": {
           "name": "Aarhus Universitet",
           "user_key": "AU",
@@ -334,7 +335,15 @@ def get_orgunit(unitid):
         "parent": {
           "name": "Historisk Institut",
           "user_key": "hist",
-          "uuid": "da77153e-30f3-4dc2-a611-ee912a28d8aa"
+          "uuid": "da77153e-30f3-4dc2-a611-ee912a28d8aa",
+          "validity": {
+            "from": "2016-01-01T00:00:00+01:00",
+            "to": "2019-01-01T00:00:00+01:00"
+          }
+        },
+        "validity": {
+          "from": "2016-01-01T00:00:00+01:00",
+          "to": "2019-01-01T00:00:00+01:00"
         }
       }
 
@@ -382,7 +391,11 @@ def list_orgunits(orgid):
           {
             "name": "Samfundsvidenskabelige fakultet",
             "user_key": "samf",
-            "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0"
+            "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
+            "validity": {
+              "from": "2017-01-01T00:00:00+01:00",
+              "to": null
+            }
           }
         ],
         "offset": 0,

--- a/tests/test_integration_address.py
+++ b/tests/test_integration_address.py
@@ -1414,9 +1414,17 @@ class Writing(util.LoRATestCase):
                     'name': 'Overordnet Enhed',
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'user_key': 'Fake Corp 00000000-0000-0000-0000-000000000000',
                 'uuid': unitid,
+                'validity': {
+                    'from': '2016-02-04T00:00:00+01:00',
+                    'to': '2017-10-22T00:00:00+02:00',
+                },
             },
         )
 

--- a/tests/test_integration_association.py
+++ b/tests/test_integration_association.py
@@ -197,6 +197,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': unitid,
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Fedtmule',
@@ -437,6 +441,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': unitid,
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Fedtmule',
@@ -641,6 +649,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Fedtmule',
@@ -873,6 +885,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Anders And',
@@ -917,6 +933,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Anders And',
@@ -1215,6 +1235,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Anders And',
@@ -1428,7 +1452,11 @@ class Tests(util.LoRATestCase):
             'org_unit': {
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
-                'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e'
+                'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Anders And',
@@ -1476,6 +1504,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Samfundsvidenskabelige fakultet',
                 'user_key': 'samf',
                 'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+                'validity': {
+                    'from': '2017-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             validity={
                 'from': '2018-04-01T00:00:00+02:00',
@@ -1664,6 +1696,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Anders And',
@@ -1686,6 +1722,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Samfundsvidenskabelige fakultet',
                 'user_key': 'samf',
                 'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+                'validity': {
+                    'from': '2017-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             validity={
                 'from': '2018-04-01T00:00:00+02:00',
@@ -1904,6 +1944,10 @@ class AddressTests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             'person': {
                 'name': 'Anders And',

--- a/tests/test_integration_importing.py
+++ b/tests/test_integration_importing.py
@@ -563,34 +563,35 @@ class IntegrationTests(util.LoRATestCase):
 
         self.assertRequestResponse(
             '/service/o/3a87187c-f25a-40a1-8d42-312b2e2b43bd/children',
-            [{'child_count': 3,
-              'name': 'Ballerup Kommune',
-              'user_key': 'BALLERUP',
-              'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4'}],
+            [{
+                'child_count': 3,
+                'name': 'Ballerup Kommune',
+                'user_key': 'BALLERUP',
+                'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                'validity': {
+                    'from': '1964-05-24T00:00:00+01:00',
+                    'to': None,
+                },
+            }],
         )
 
         self.assertRequestResponse(
             '/service/ou/9f42976b-93be-4e0b-9a25-0dcb8af2f6b4/children',
-            [
-                {
-                    "child_count": 0,
-                    "name": "Ballerup Bibliotek",
-                    "user_key": "BIBLIOTEK",
-                    "uuid": "921e44d3-2ec0-4c16-9935-2ec7976566dc"
-                },
-                {
-                    "child_count": 0,
-                    "name": "Ballerup Familiehus",
-                    "user_key": "FAMILIEHUS",
-                    "uuid": "c12393e9-ee1d-4b91-a6a9-a17508c055c9"
-                },
-                {
-                    "child_count": 0,
-                    "name": "Ballerup Idr\u00e6tspark",
-                    "user_key": "IDR\u00c6TSPARK",
-                    "uuid": "ef04b6ba-8ba7-4a25-95e3-774f38e5d9bc"
-                }
-            ],
+            [{'child_count': 0,
+              'name': 'Ballerup Bibliotek',
+              'user_key': 'BIBLIOTEK',
+              'uuid': '921e44d3-2ec0-4c16-9935-2ec7976566dc',
+              'validity': {'from': '1993-01-01T00:00:00+01:00', 'to': None}},
+             {'child_count': 0,
+              'name': 'Ballerup Familiehus',
+              'user_key': 'FAMILIEHUS',
+              'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9',
+              'validity': {'from': '2006-01-01T00:00:00+01:00', 'to': None}},
+             {'child_count': 0,
+              'name': 'Ballerup Idrætspark',
+              'user_key': 'IDRÆTSPARK',
+              'uuid': 'ef04b6ba-8ba7-4a25-95e3-774f38e5d9bc',
+              'validity': {'from': '1993-01-01T00:00:00+01:00', 'to': None}}],
         )
 
         for childid in (
@@ -622,6 +623,10 @@ class IntegrationTests(util.LoRATestCase):
                     'uuid': 'f2f93f92-d08f-4b76-904f-af9144e23195',
                 },
                 'parent': None,
+                'validity': {
+                    'from': '1964-05-24T00:00:00+01:00',
+                    'to': None,
+                },
             },
         )
 
@@ -629,43 +634,56 @@ class IntegrationTests(util.LoRATestCase):
             '/service/ou/c12393e9-ee1d-4b91-a6a9-a17508c055c9/',
             {
                 'name': 'Ballerup Familiehus',
-                'user_key': 'FAMILIEHUS',
-                'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9',
                 'org': {'name': 'Ballerup Kommune',
                         'user_key': 'Ballerup Kommune',
                         'uuid': '3a87187c-f25a-40a1-8d42-312b2e2b43bd'},
-                'org_unit_type': {'example': None,
-                                  'name': 'Fagligt Center',
-                                  'scope': None,
-                                  'user_key': 'Fagligt Center',
-                                  'uuid': '59f10075-88f6-4758-bf61-'
-                                  '454858170776'},
-                'parent': {'name': 'Ballerup Kommune',
-                           'user_key': 'BALLERUP',
-                           'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4'},
+                'org_unit_type': {
+                    'example': None,
+                    'name': 'Fagligt Center',
+                    'scope': None,
+                    'user_key': 'Fagligt Center',
+                    'uuid': '59f10075-88f6-4758-bf61-454858170776',
+                },
+                'parent': {
+                    'name': 'Ballerup Kommune',
+                    'user_key': 'BALLERUP',
+                    'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                    'validity': {
+                        'from': '1964-05-24T00:00:00+01:00',
+                        'to': None,
+                    },
+                },
+                'user_key': 'FAMILIEHUS',
+                'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9',
+                'validity': {'from': '2006-01-01T00:00:00+01:00', 'to': None},
             },
         )
 
         self.assertRequestResponse(
             '/service/o/3a87187c-f25a-40a1-8d42-312b2e2b43bd/ou/',
-            {
-                'items': [
-                    {'name': 'Ballerup Bibliotek',
-                     'user_key': 'BIBLIOTEK',
-                     'uuid': '921e44d3-2ec0-4c16-9935-2ec7976566dc'},
-                    {'name': 'Ballerup Kommune',
-                     'user_key': 'BALLERUP',
-                     'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4'},
-                    {'name': 'Ballerup Familiehus',
-                     'user_key': 'FAMILIEHUS',
-                     'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9'},
-                    {'name': 'Ballerup Idrætspark',
-                     'user_key': 'IDRÆTSPARK',
-                     'uuid': 'ef04b6ba-8ba7-4a25-95e3-774f38e5d9bc'}
-                ],
-                'offset': 0,
-                'total': 4
-            }
+            {'items': [
+                {'name': 'Ballerup Bibliotek',
+                 'user_key': 'BIBLIOTEK',
+                 'uuid': '921e44d3-2ec0-4c16-9935-2ec7976566dc',
+                 'validity': {'from': '1993-01-01T00:00:00+01:00',
+                              'to': None}},
+                {'name': 'Ballerup Kommune',
+                 'user_key': 'BALLERUP',
+                 'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                 'validity': {'from': '1964-05-24T00:00:00+01:00',
+                              'to': None}},
+                {'name': 'Ballerup Familiehus',
+                 'user_key': 'FAMILIEHUS',
+                 'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9',
+                 'validity': {'from': '2006-01-01T00:00:00+01:00',
+                              'to': None}},
+                {'name': 'Ballerup Idrætspark',
+                 'user_key': 'IDRÆTSPARK',
+                 'uuid': 'ef04b6ba-8ba7-4a25-95e3-774f38e5d9bc',
+                 'validity': {'from': '1993-01-01T00:00:00+01:00',
+                              'to': None}}],
+             'offset': 0,
+             'total': 4},
         )
 
         self.assertRequestResponse(
@@ -2404,6 +2422,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            }
                         },
                         'person': {
                             'name': 'Sune Skriver',
@@ -2436,10 +2458,15 @@ class IntegrationTests(util.LoRATestCase):
                         'user_key': 'Administrativ leder',
                         'uuid': 'ee8dd627-9ff1-47c2-b900-aa3c214a31ee',
                     },
-                    'org_unit': {'name': 'Ballerup Kommune',
-                                 'user_key': 'BALLERUP',
-                                 'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4'
-                                 },
+                    'org_unit': {
+                        'name': 'Ballerup Kommune',
+                        'user_key': 'BALLERUP',
+                        'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                        'validity': {
+                            'from': '1964-05-24T00:00:00+01:00',
+                            'to': None,
+                        },
+                    },
                     'person': {'name': 'Sanne Schäff',
                                'uuid': '1ce40e25-6238-4202-9e93-526b348ec745'},
                     'engagement_type': {
@@ -2473,6 +2500,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'person': {
                             'name': 'Sanne Schäff',
@@ -2503,6 +2534,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'person': {
                             'name': 'Sune Skriver',
@@ -2548,6 +2583,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'person': {
                             'name': 'Sanne Schäff',
@@ -2586,6 +2625,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'person': {
                             'name': 'Sanne Schäff',
@@ -2618,6 +2661,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'person': {
                             'name': 'Sanne Schäff',
@@ -2648,6 +2695,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'person': {
                             'name': 'Sanne Schäff',
@@ -2739,6 +2790,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'uuid': '8fb49f61-db3f-4f61-92c3-8a1dddd8051f',
                         "validity": {
@@ -2784,6 +2839,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'uuid': '8fb49f61-db3f-4f61-92c3-8a1dddd8051f',
                         "validity": {
@@ -3127,6 +3186,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'validity': {
                             'from': '1993-01-01T00:00:00+01:00',
@@ -3161,6 +3224,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'validity': {
                             'from': '2006-01-01T00:00:00+01:00',
@@ -3195,6 +3262,10 @@ class IntegrationTests(util.LoRATestCase):
                             'name': 'Ballerup Kommune',
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
+                            'validity': {
+                                'from': '1964-05-24T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         'validity': {
                             'from': '1993-01-01T00:00:00+01:00',

--- a/tests/test_integration_manager.py
+++ b/tests/test_integration_manager.py
@@ -224,6 +224,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Humanistisk fakultet',
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Fedtmule',
@@ -403,6 +407,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Humanistisk fakultet',
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Fedtmule',
@@ -535,6 +543,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Humanistisk fakultet',
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Fedtmule',
@@ -793,6 +805,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Humanistisk fakultet',
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Anders And',
@@ -847,6 +863,9 @@ class Tests(util.LoRATestCase):
                     'name': 'Filosofisk Institut',
                     'user_key': 'fil',
                     'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Anders And',
@@ -1137,6 +1156,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Filosofisk Institut',
                     'user_key': 'fil',
                     'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Anders And',
@@ -1328,6 +1351,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Humanistisk fakultet',
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Anders And',
@@ -1499,7 +1526,9 @@ class Tests(util.LoRATestCase):
                              '94c6-70b192eff825'},
             'org_unit': {'name': 'Humanistisk fakultet',
                          'user_key': 'hum',
-                         'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e'},
+                         'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                         'validity': {'from': '2016-01-01T00:00:00+01:00',
+                                      'to': None}},
             'person': {'name': 'Anders And',
                        'uuid': '53181ed2-f1de-4c4a-a8fd-ab358c2c454a'},
             'responsibility': {'example': None,

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -42,6 +42,10 @@ class Tests(util.LoRATestCase):
                         'name': 'Historisk Institut',
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                     "org": {
                         "name": "Aarhus Universitet",
@@ -80,6 +84,10 @@ class Tests(util.LoRATestCase):
                         'name': 'Historisk Institut',
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                     "validity": {
                         "from": "2017-01-01T00:00:00+01:00",
@@ -113,6 +121,10 @@ class Tests(util.LoRATestCase):
                         'name': 'Historisk Institut',
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                     "validity": {
                         "from": "2018-01-01T00:00:00+01:00",
@@ -145,7 +157,11 @@ class Tests(util.LoRATestCase):
                     'parent': {
                         'name': 'Historisk Institut',
                         'user_key': 'hist',
-                        'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa'
+                        'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                     'validity': {
                         'from': '2016-01-01T00:00:00+01:00',
@@ -171,7 +187,11 @@ class Tests(util.LoRATestCase):
                     'parent': {
                         'name': 'Historisk Institut',
                         'user_key': 'hist',
-                        'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa'
+                        'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                     'validity': {
                         'from': '2017-01-01T00:00:00+01:00',
@@ -197,7 +217,11 @@ class Tests(util.LoRATestCase):
                     'parent': {
                         'name': 'Historisk Institut',
                         'user_key': 'hist',
-                        'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa'
+                        'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                     'validity': {
                         'from': '2018-01-01T00:00:00+01:00',
@@ -378,9 +402,17 @@ class Tests(util.LoRATestCase):
                     'name': 'Overordnet Enhed',
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'user_key': 'Fake Corp f494ad89-039d-478e-91f2-a63566554bd6',
                 'uuid': unitid,
+                'validity': {
+                    'from': '2016-02-04T00:00:00+01:00',
+                    'to': '2017-10-22T00:00:00+02:00',
+                }
             },
         )
 
@@ -919,6 +951,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Overordnet Enhed',
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'user_key': 'samf',
                 'uuid': org_unit_uuid,
@@ -1198,9 +1234,15 @@ class Tests(util.LoRATestCase):
                                            '88a9-31e02e420e52'},
                  'parent': {'name': 'Humanistisk fakultet',
                             'user_key': 'hum',
-                            'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e'},
+                            'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                            'validity': {'from': '2016-01-01T00:00:00+01:00',
+                                         'to': None}},
                  'user_key': 'fil',
                  'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                 'validity': {
+                     'from': '2016-01-01T00:00:00+01:00',
+                     'to': None,
+                 },
                  'validity': {'from': '2016-01-01T00:00:00+01:00',
                               'to': '2016-10-22T00:00:00+02:00'}}]
         )
@@ -1252,6 +1294,10 @@ class Tests(util.LoRATestCase):
                         'name': 'Afdeling for Fortidshistorik',
                         'user_key': 'frem',
                         'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                 ],
             },
@@ -1283,12 +1329,20 @@ class Tests(util.LoRATestCase):
                         'name': 'Filosofisk Institut',
                         'user_key': 'fil',
                         'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': None,
+                        },
                     },
                     {
                         'child_count': 1,
                         'name': 'Historisk Institut',
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     },
                 ],
             },
@@ -1320,6 +1374,10 @@ class Tests(util.LoRATestCase):
                         'name': 'Filosofisk Institut',
                         'user_key': 'fil',
                         'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': None,
+                        },
                     },
                 ],
             },

--- a/tests/test_integration_service.py
+++ b/tests/test_integration_service.py
@@ -159,6 +159,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Overordnet Enhed',
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
             ],
         )
@@ -178,6 +182,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Overordnet Enhed',
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
             ],
         )
@@ -189,12 +197,20 @@ class Tests(util.LoRATestCase):
                     "name": "Humanistisk fakultet",
                     "user_key": "hum",
                     "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                    "validity": {
+                        "from": "2016-01-01T00:00:00+01:00",
+                        "to": None,
+                    },
                     "child_count": 2,
                 },
                 {
                     "name": "Samfundsvidenskabelige fakultet",
                     "user_key": "samf",
                     "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
+                    "validity": {
+                        "from": "2017-01-01T00:00:00+01:00",
+                        "to": None,
+                    },
                     "child_count": 0,
                 }
             ],
@@ -208,31 +224,55 @@ class Tests(util.LoRATestCase):
                 'user_key': 'frem',
                 'name': 'Afdeling for Samtidshistorik',
                 'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': '2019-01-01T00:00:00+01:00',
+                },
             },
             {
                 'user_key': 'root',
                 'name': 'Overordnet Enhed',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             {
                 'user_key': 'fil',
                 'name': 'Filosofisk Institut',
                 'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             {
                 'user_key': 'hum',
                 'name': 'Humanistisk fakultet',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             {
                 'user_key': 'samf',
                 'name': 'Samfundsvidenskabelige fakultet',
                 'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+                'validity': {
+                    'from': '2017-01-01T00:00:00+01:00',
+                    'to': None,
+                },
             },
             {
                 'user_key': 'hist',
                 'name': 'Historisk Institut',
                 'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': '2019-01-01T00:00:00+01:00',
+                },
             },
         ]
 
@@ -255,11 +295,19 @@ class Tests(util.LoRATestCase):
                             'user_key': 'hum',
                             'name': 'Humanistisk fakultet',
                             'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         {
                             'user_key': 'hist',
                             'name': 'Historisk Institut',
                             'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': '2019-01-01T00:00:00+01:00',
+                            },
                         },
                     ],
                     'offset': 0,
@@ -288,16 +336,28 @@ class Tests(util.LoRATestCase):
                             'user_key': 'root',
                             'name': 'Overordnet Enhed',
                             'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         {
                             'user_key': 'hum',
                             'name': 'Humanistisk fakultet',
                             'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         {
                             'user_key': 'hist',
                             'name': 'Historisk Institut',
                             'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': '2019-01-01T00:00:00+01:00',
+                            },
                         },
                     ],
                     'offset': 0,
@@ -314,16 +374,28 @@ class Tests(util.LoRATestCase):
                             'user_key': 'frem',
                             'name': 'Afdeling for Samtidshistorik',
                             'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': '2019-01-01T00:00:00+01:00',
+                            },
                         },
                         {
                             'user_key': 'fil',
                             'name': 'Filosofisk Institut',
                             'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                         {
                             'user_key': 'samf',
                             'name': 'Samfundsvidenskabelige fakultet',
                             'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+                            'validity': {
+                                'from': '2017-01-01T00:00:00+01:00',
+                                'to': None,
+                            },
                         },
                     ],
                     'offset': 3,
@@ -337,9 +409,13 @@ class Tests(util.LoRATestCase):
                 '?query=frem',
                 {
                     'items': [{
-                        'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                         'name': 'Afdeling for Samtidshistorik',
                         'user_key': 'frem',
+                        'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2019-01-01T00:00:00+01:00',
+                        },
                     }],
                     'offset': 0,
                     'total': 1
@@ -354,6 +430,10 @@ class Tests(util.LoRATestCase):
                         'name': 'Overordnet Enhed',
                         'user_key': 'root',
                         'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                        'validity': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': None,
+                        },
                     }],
                     'offset': 0,
                     'total': 1
@@ -381,6 +461,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Overordnet Enhed',
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
                 'org': {
                     'name': 'Aarhus Universitet',
                     'user_key': 'AU',
@@ -404,6 +488,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Overordnet Enhed',
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
                 'org': {
                     'name': 'Aarhus Universitet',
                     'user_key': 'AU',
@@ -437,6 +525,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Overordnet Enhed',
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
                 'org': {
                     'name': 'Aarhus Universitet',
                     'user_key': 'AU',
@@ -462,6 +554,10 @@ class Tests(util.LoRATestCase):
                 'name': 'Overordnet Enhed',
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                'validity': {
+                    'from': '2016-01-01T00:00:00+01:00',
+                    'to': None,
+                },
                 'org': {
                     'name': 'Aarhus Universitet',
                     'user_key': 'AU',
@@ -483,11 +579,15 @@ class Tests(util.LoRATestCase):
             [{'child_count': 2,
               'name': 'Humanistisk fakultet',
               'user_key': 'hum',
-              'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e'},
+              'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+              'validity': {'from': '2016-01-01T00:00:00+01:00',
+                           'to': None}},
              {'child_count': 0,
               'name': 'Samfundsvidenskabelige fakultet',
               'user_key': 'samf',
-              'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0'}],
+              'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+              'validity': {'from': '2017-01-01T00:00:00+01:00',
+                           'to': None}}],
         )
 
     def test_employee(self):
@@ -757,6 +857,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Humanistisk fakultet',
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Anders And',
@@ -831,6 +935,10 @@ class Tests(util.LoRATestCase):
                     'name': 'Humanistisk fakultet',
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                    'validity': {
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': None,
+                    },
                 },
                 'person': {
                     'name': 'Anders And',
@@ -997,6 +1105,10 @@ class Tests(util.LoRATestCase):
                     "name": "Humanistisk fakultet",
                     "user_key": "hum",
                     "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
+                    "validity": {
+                        "from": "2016-01-01T00:00:00+01:00",
+                        "to": None,
+                    },
                 },
                 'manager_type': {
                     'example': None,


### PR DESCRIPTION
We generally only return the current validity, on the general
assumption that this will span a sufficiently long interval.

This change supersedes #114.