### PR TITLE
#23182 parent checks

### DIFF
--- a/mora/exceptions.py
+++ b/mora/exceptions.py
@@ -51,7 +51,7 @@ class ErrorCodes(Enum):
     V_NO_ACTIVE_ENGAGEMENT = \
         400, "Employee must have an active engagement."
     V_UNIT_OUTSIDE_ORG = \
-        400, "Unit does not belong to the same organisation."
+        400, "Unit belongs to an organisation different from the current one."
 
     # Input errors
     E_ORG_UNIT_NOT_FOUND = 404, "Org unit not found."

--- a/mora/exceptions.py
+++ b/mora/exceptions.py
@@ -50,6 +50,8 @@ class ErrorCodes(Enum):
              "org unit."
     V_NO_ACTIVE_ENGAGEMENT = \
         400, "Employee must have an active engagement."
+    V_UNIT_OUTSIDE_ORG = \
+        400, "Unit does not belong to the same organisation."
 
     # Input errors
     E_ORG_UNIT_NOT_FOUND = 404, "Org unit not found."

--- a/mora/service/common.py
+++ b/mora/service/common.py
@@ -735,6 +735,11 @@ def replace_relation_value(relations: typing.List[dict],
             exceptions.ErrorCodes.E_ORIGINAL_ENTRY_NOT_FOUND)
 
 
+def get_states(reg):
+    for tilstand in reg.get('tilstande', {}).values():
+        yield from tilstand
+
+
 def is_reg_valid(reg):
     """
     Check if a given registration is valid
@@ -744,9 +749,8 @@ def is_reg_valid(reg):
     """
 
     return any(
-        gyldighed_obj.get('gyldighed') == 'Aktiv'
-        for tilstand in reg.get('tilstande', {}).values()
-        for gyldighed_obj in tilstand
+        state.get('gyldighed') == 'Aktiv'
+        for state in get_states(reg)
     )
 
 

--- a/mora/validator.py
+++ b/mora/validator.py
@@ -176,7 +176,7 @@ def is_candidate_parent_valid(unitid: str, parent: str,
 
         parentobj = c.organisationenhed.get(uuid=parent)
 
-        if not parent:
+        if not parentobj:
             raise exceptions.HTTPException(
                 exceptions.ErrorCodes.E_ORG_UNIT_NOT_FOUND,
                 org_unit_uuid=parent,

--- a/mora/validator.py
+++ b/mora/validator.py
@@ -9,6 +9,7 @@ import datetime
 from . import exceptions
 from . import lora
 from . import util
+from .service import common
 from .service import keys
 
 
@@ -109,41 +110,64 @@ def is_candidate_parent_valid(unitid: str, parent: str,
     """
     # Do not allow moving of the root org unit
     c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
     org_unit_relations = c.organisationenhed.get(
         uuid=unitid
     )['relationer']
-    if org_unit_relations['overordnet'][0]['uuid'] == \
-            org_unit_relations['tilhoerer'][0]['uuid']:
+    orgid = org_unit_relations['tilhoerer'][0]['uuid']
+
+    if org_unit_relations['overordnet'][0]['uuid'] == orgid:
         raise exceptions.HTTPException(
             exceptions.ErrorCodes.V_CANNOT_MOVE_ROOT_ORG_UNIT)
 
     # Use for checking that the candidate parent is not the units own subtree
+    seen = {unitid}
+
     c = lora.Connector(effective_date=from_date)
 
-    def is_node_valid(node_uuid: str) -> bool:
-        if node_uuid == unitid:
-            return False
+    while True:
+        # this captures moving to a child as well as moving into a loop
+        if parent in seen:
+            raise exceptions.HTTPException(
+                exceptions.ErrorCodes.V_ORG_UNIT_MOVE_TO_CHILD,
+                org_unit_uuid=parent,
+            )
 
-        node = c.organisationenhed.get(
-            uuid=node_uuid
-        )
+        seen.add(parent)
 
-        # Check that the node is not inactive
-        if node['tilstande']['organisationenhedgyldighed'][0]['gyldighed'] == \
-                'Inaktiv':
-            return False
+        parentobj = c.organisationenhed.get(uuid=parent)
 
-        node_relations = node['relationer']
-        parent = node_relations['overordnet'][0]['uuid']
-        if parent == node_relations['tilhoerer'][0]['uuid']:
-            # Root org unit
-            return True
+        if not parent:
+            raise exceptions.HTTPException(
+                exceptions.ErrorCodes.E_ORG_UNIT_NOT_FOUND,
+                org_unit_uuid=parent,
+            )
 
-        return is_node_valid(parent)
+        # ensure the parent is active
+        if not common.is_reg_valid(parentobj):
+            raise exceptions.HTTPException(
+                exceptions.ErrorCodes.V_DATE_OUTSIDE_ORG_UNIT_RANGE,
+                org_unit_uuid=parent,
+            )
 
-    if not is_node_valid(parent):
-        raise exceptions.HTTPException(
-            exceptions.ErrorCodes.V_ORG_UNIT_MOVE_TO_CHILD)
+        parentorg = parentobj['relationer']['tilhoerer'][0]['uuid']
+
+        # ensure it's in the same organisation
+        if parentorg != orgid:
+            raise exceptions.HTTPException(
+                exceptions.ErrorCodes.V_UNIT_OUTSIDE_ORG,
+                org_unit_uuid=parent,
+                current_org_uuid=orgid,
+                target_org_uuid=parentorg,
+            )
+
+        # now switch to the next parent
+        parent = parentobj['relationer']['overordnet'][0]['uuid']
+
+        # after iterating at least once, have we hit a proper root node?
+        # if so, we're done!
+        if parent == orgid:
+            break
 
 
 def is_org_unit_termination_date_valid(unitid: str, end_date: datetime):

--- a/mora/validator.py
+++ b/mora/validator.py
@@ -23,7 +23,7 @@ def _is_date_range_valid(parent: typing.Union[dict, str],
     """
     Determine if the given dates are within validity of the parent unit.
 
-    :param parent: The UUID of the parent unit.
+    :param parent: Ether the UUID of the parent unit, or a dict containing it.
     :param startdate: The candidate start date.
     :param enddate: The candidate end date.
     :param lora_scope: A scope object from a LoRa connector.

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -765,6 +765,326 @@ class Tests(util.LoRATestCase):
 
         self.assertRegistrationsEqual(expected, actual)
 
+    def test_edit_org_unit_earlier_start(self):
+        # A generic example of editing an org unit
+
+        self.load_sample_structures()
+
+        org_unit_uuid = 'b688513d-11f7-4efc-b679-ab082a2055d0'
+
+        with self.subTest('too soon'):
+            self.assertRequestResponse(
+                '/service/ou/{}/edit'.format(org_unit_uuid),
+                {
+                    'description': 'Date range exceeds validity range of '
+                    'associated org unit.',
+                    'error': True,
+                    'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
+                    'org_unit_uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                    'status': 400,
+                    'valid_from': '2010-01-01T00:00:00+01:00',
+                    'valid_to': None,
+                },
+                status_code=400,
+                json={
+                    "data": {
+                        "validity": {
+                            "from": "2010-01-01",
+                        },
+                    },
+                },
+            )
+
+        with self.subTest('too soon, with parent'):
+            self.assertRequestResponse(
+                '/service/ou/{}/edit'.format(org_unit_uuid),
+                {
+                    'description': 'Date range exceeds validity range of '
+                    'associated org unit.',
+                    'error': True,
+                    'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
+                    'org_unit_uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                    'status': 400,
+                },
+                status_code=400,
+                json={
+                    "data": {
+                        'parent': {
+                            'name': 'Overordnet Enhed',
+                            'user_key': 'root',
+                            'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                            'validity': {
+                                'from': '2016-01-01T00:00:00+01:00',
+                                'to': None,
+                            },
+                        },
+                        "validity": {
+                            "from": "2010-01-01",
+                        },
+                    },
+                },
+            )
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            org_unit_uuid, json={
+                "data": {
+                    "validity": {
+                        "from": "2016-06-01",
+                    },
+                },
+            },
+        )
+
+        expected = {
+            'attributter': {
+                'organisationenhedegenskaber': [
+                    {
+                        'brugervendtnoegle': 'samf',
+                        'enhedsnavn': 'Samfundsvidenskabelige fakultet',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+            },
+            'livscykluskode': 'Rettet',
+            'note': 'Rediger organisationsenhed',
+            'relationer': {
+                'adresser': [
+                    {
+                        'objekttype': '1d1d3711-5af4-4084-99b3-df2b8752fdec',
+                        'urn': 'urn:magenta.dk:telefon:+4587150000',
+                        'virkning': {
+                            'from': '2017-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                    {
+                        'objekttype': '4e337d8e-1fd2-4449-8110-e0c8a22958ed',
+                        'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
+                        'virkning': {
+                            'from': '2017-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+                'enhedstype': [
+                    {
+                        'uuid': '4311e351-6a3c-4e7e-ae60-8a3b2938fbd6',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+                'overordnet': [
+                    {
+                        'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+                'tilhoerer': [
+                    {
+                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+            },
+            'tilstande': {
+                'organisationenhedgyldighed': [
+                    {
+                        'gyldighed': 'Aktiv',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+            },
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual = c.organisationenhed.get(org_unit_uuid)
+
+        self.assertRegistrationsEqual(expected, actual)
+
+    @util.mock('aabogade.json', allow_mox=True)
+    def test_edit_org_unit_earlier_start_on_created(self, m):
+        self.load_sample_structures()
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+
+        payload = {
+            "name": "Fake Corp",
+            "parent": {
+                'uuid': "2874e1dc-85e6-4269-823a-e1125484dfd3"
+            },
+            "org_unit_type": {
+                'uuid': "ca76a441-6226-404f-88a9-31e02e420e52"
+            },
+            "addresses": [
+                {
+                    "address_type": {
+                        "example": "20304060",
+                        "name": "Telefonnummer",
+                        "scope": "PHONE",
+                        "user_key": "Telefon",
+                        "uuid": "1d1d3711-5af4-4084-99b3-df2b8752fdec",
+                    },
+                    "value": "11 22 33 44",
+                },
+                {
+                    "address_type": {
+                        "example": "<UUID>",
+                        "name": "Adresse",
+                        "scope": "DAR",
+                        "user_key": "Adresse",
+                        "uuid": "4e337d8e-1fd2-4449-8110-e0c8a22958ed"
+                    },
+                    "uuid": "44c532e1-f617-4174-b144-d37ce9fda2bd",
+                },
+            ],
+            "validity": {
+                "from": "2017-01-01",
+                "to": "2018-01-01",
+            }
+        }
+
+        r = self.request('/service/ou/create', json=payload)
+        self.assert200(r)
+        org_unit_uuid = r.json
+
+        req = {
+            "data": {
+                "validity": {
+                    "from": "2016-06-01",
+                },
+            },
+        }
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            org_unit_uuid,
+            json=req,
+        )
+
+        expected = {
+            'attributter': {
+                'organisationenhedegenskaber': [
+                    {
+                        'brugervendtnoegle': 'Fake Corp '
+                        'f494ad89-039d-478e-91f2-a63566554bd6',
+                        'enhedsnavn': 'Fake Corp',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+            },
+            'livscykluskode': 'Rettet',
+            'note': 'Rediger organisationsenhed',
+            'relationer': {
+                'adresser': [
+                    {
+                        'objekttype': '1d1d3711-5af4-4084-99b3-df2b8752fdec',
+                        'urn': 'urn:magenta.dk:telefon:+4511223344',
+                        'virkning': {
+                            'from': '2017-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': '2018-01-01 00:00:00+01',
+                            'to_included': False,
+                        },
+                    },
+                    {
+                        'objekttype': '4e337d8e-1fd2-4449-8110-e0c8a22958ed',
+                        'uuid': '44c532e1-f617-4174-b144-d37ce9fda2bd',
+                        'virkning': {
+                            'from': '2017-01-01 00:00:00+01',
+                            'from_included': True,
+                            'to': '2018-01-01 00:00:00+01',
+                            'to_included': False,
+                        },
+                    },
+                ],
+                'enhedstype': [
+                    {
+                        'uuid': 'ca76a441-6226-404f-88a9-31e02e420e52',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+                'overordnet': [
+                    {
+                        'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+                'tilhoerer': [
+                    {
+                        'uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+            },
+            'tilstande': {
+                'organisationenhedgyldighed': [
+                    {
+                        'gyldighed': 'Aktiv',
+                        'virkning': {
+                            'from': '2016-06-01 00:00:00+02',
+                            'from_included': True,
+                            'to': 'infinity',
+                            'to_included': False,
+                        },
+                    },
+                ],
+            },
+        }
+
+        c = lora.Connector(virkningfra='-infinity', virkningtil='infinity')
+        actual = c.organisationenhed.get(org_unit_uuid)
+
+        self.assertRegistrationsEqual(expected, actual)
+
     def test_rename_org_unit(self):
         # A generic example of editing an org unit
 
@@ -1130,6 +1450,7 @@ class Tests(util.LoRATestCase):
                                'one of its own child units',
                 'error': True,
                 'error_key': 'V_ORG_UNIT_MOVE_TO_CHILD',
+                'org_unit_uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'status': 400
             },
             status_code=400,
@@ -1217,6 +1538,133 @@ class Tests(util.LoRATestCase):
             },
             status_code=400,
             json=req)
+
+    def test_move_org_unit_wrong_org(self):
+        # A generic example of editing an org unit
+
+        self.load_sample_structures()
+
+        org_unit_uuid = 'b688513d-11f7-4efc-b679-ab082a2055d0'
+        other_org_uuid = util.load_fixture(
+            'organisation/organisation',
+            'create_organisation_AU.json',
+        )
+
+        c = lora.Connector()
+
+        other_unit = util.get_fixture('create_organisationenhed_root.json')
+        other_unit['relationer']['tilhoerer'][0]['uuid'] = other_org_uuid
+        other_unit['relationer']['overordnet'][0]['uuid'] = other_org_uuid
+
+        other_unit_uuid = c.organisationenhed.create(other_unit)
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            {
+                'description': 'Unit does not belong to the same '
+                'organisation.',
+                'error': True,
+                'error_key': 'V_UNIT_OUTSIDE_ORG',
+                'org_unit_uuid': other_unit_uuid,
+                'current_org_uuid': '456362c4-0ee4-4e5e-a72c-751239745e62',
+                'target_org_uuid': other_org_uuid,
+                'status': 400,
+            },
+            status_code=400,
+            json={
+                "data": {
+                    "parent": {
+                        'uuid': other_unit_uuid,
+                    },
+                    "validity": {
+                        "from": "2018-01-01T00:00:00+02",
+                    },
+                },
+            },
+        )
+
+    def test_move_org_autoparent(self):
+        # A generic example of editing an org unit
+
+        self.load_sample_structures()
+
+        root_uuid = '2874e1dc-85e6-4269-823a-e1125484dfd3'
+        org_unit_uuid = 'b688513d-11f7-4efc-b679-ab082a2055d0'
+
+        c = lora.Connector()
+        c.organisationenhed.update(
+            {
+                'relationer': {
+                    'overordnet': [{
+                        'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+                        'virkning': {
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': 'infinity',
+                        },
+                    }],
+                },
+            },
+            root_uuid,
+        )
+
+        self.assertEqual(
+            c.organisationenhed.get(root_uuid)['relationer']['overordnet'],
+            [{
+                'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+                'virkning': {
+                    'from': '2016-01-01 00:00:00+01',
+                    'from_included': True,
+                    'to': 'infinity',
+                    'to_included': False,
+                },
+            }],
+        )
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            {
+                'description': 'Org unit cannot be moved to one of its own '
+                'child units',
+                'error': True,
+                'error_key': 'V_ORG_UNIT_MOVE_TO_CHILD',
+                'status': 400,
+                'org_unit_uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
+            },
+            status_code=400,
+            json={
+                "data": {
+                    "parent": {
+                        'uuid': root_uuid,
+                    },
+                    "validity": {
+                        "from": "2018-01-01T00:00:00+02",
+                    },
+                },
+            },
+        )
+
+        self.assertRequestResponse(
+            '/service/ou/9d07123e-47ac-4a9a-88c8-da82e3a4bc9e/edit',
+            {
+                'description': 'Org unit cannot be moved to one of its own '
+                'child units',
+                'error': True,
+                'error_key': 'V_ORG_UNIT_MOVE_TO_CHILD',
+                'status': 400,
+                'org_unit_uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
+            },
+            status_code=400,
+            json={
+                "data": {
+                    "parent": {
+                        'uuid': root_uuid,
+                    },
+                    "validity": {
+                        "from": "2018-01-01T00:00:00+02",
+                    },
+                },
+            },
+        )
 
     def test_edit_org_unit_should_fail_validation_when_end_before_start(self):
         """Should fail validation when trying to edit an org unit with the

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -1666,6 +1666,35 @@ class Tests(util.LoRATestCase):
             },
         )
 
+    def test_move_org_nowhere(self):
+        "Verify that we cannot move units to places that don't exist"
+
+        self.load_sample_structures()
+
+        org_unit_uuid = 'b688513d-11f7-4efc-b679-ab082a2055d0'
+
+        self.assertRequestResponse(
+            '/service/ou/{}/edit'.format(org_unit_uuid),
+            {
+                'description': 'Org unit not found.',
+                'error': True,
+                'error_key': 'E_ORG_UNIT_NOT_FOUND',
+                'org_unit_uuid': '00000000-0000-0000-0000-000000000001',
+                'status': 404,
+            },
+            status_code=404,
+            json={
+                "data": {
+                    "parent": {
+                        'uuid': "00000000-0000-0000-0000-000000000001",
+                    },
+                    "validity": {
+                        "from": "2017-01-01",
+                    },
+                },
+            },
+        )
+
     def test_edit_org_unit_should_fail_validation_when_end_before_start(self):
         """Should fail validation when trying to edit an org unit with the
         to-time being before the from-time """

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -477,8 +477,8 @@ class Tests(util.LoRATestCase):
             'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
             'org_unit_uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
             'status': 400,
-            'valid_from': '2010-02-04T00:00:00+01:00',
-            'valid_to': '2017-10-22T00:00:00+02:00'
+            'valid_from': '2016-01-01T00:00:00+01:00',
+            'valid_to': None,
         }
 
         self.assertRequestResponse('/service/ou/create', expected,
@@ -782,7 +782,7 @@ class Tests(util.LoRATestCase):
                     'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                     'org_unit_uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                     'status': 400,
-                    'valid_from': '2010-01-01T00:00:00+01:00',
+                    'valid_from': '2016-01-01T00:00:00+01:00',
                     'valid_to': None,
                 },
                 status_code=400,
@@ -1475,7 +1475,7 @@ class Tests(util.LoRATestCase):
                     'org_unit_uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                     'status': 400,
                     'valid_from': '2016-01-01T00:00:00+01:00',
-                    'valid_to': None,
+                    'valid_to': '2019-01-01T00:00:00+01:00',
                 },
                 status_code=400,
                 json={
@@ -1497,7 +1497,7 @@ class Tests(util.LoRATestCase):
                     'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                     'org_unit_uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                     'status': 400,
-                    'valid_from': '2010-01-01T00:00:00+01:00',
+                    'valid_from': '2016-01-01T00:00:00+01:00',
                     'valid_to': '2019-01-01T00:00:00+01:00',
                 },
                 status_code=400,

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -1293,10 +1293,6 @@ class Tests(util.LoRATestCase):
                                          'to': None}},
                  'user_key': 'fil',
                  'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
-                 'validity': {
-                     'from': '2016-01-01T00:00:00+01:00',
-                     'to': None,
-                 },
                  'validity': {'from': '2016-01-01T00:00:00+01:00',
                               'to': '2016-10-22T00:00:00+02:00'}}]
         )

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -1135,6 +1135,60 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json=req)
 
+    def test_cannot_extend_beyond_parent(self):
+        """Should fail validation since the new validity period extends beyond
+        that of the parent. (#23155)"""
+
+        self.load_sample_structures()
+
+        org_unit_uuid = '04c78fc2-72d2-4d02-b55f-807af19eac48'
+
+        with self.subTest('too late'):
+            self.assertRequestResponse(
+                '/service/ou/{}/edit'.format(org_unit_uuid),
+                {
+                    'description': 'Date range exceeds validity range of '
+                    'associated org unit.',
+                    'error': True,
+                    'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
+                    'org_unit_uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                    'status': 400,
+                    'valid_from': '2016-01-01T00:00:00+01:00',
+                    'valid_to': None,
+                },
+                status_code=400,
+                json={
+                    "data": {
+                        "validity": {
+                            "from": "2016-01-01T00:00:00+01:00",
+                            "to": None,
+                        },
+                    },
+                })
+
+        with self.subTest('too soon'):
+            self.assertRequestResponse(
+                '/service/ou/{}/edit'.format(org_unit_uuid),
+                {
+                    'description': 'Date range exceeds validity range of '
+                    'associated org unit.',
+                    'error': True,
+                    'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
+                    'org_unit_uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
+                    'status': 400,
+                    'valid_from': '2010-01-01T00:00:00+01:00',
+                    'valid_to': '2019-01-01T00:00:00+01:00',
+                },
+                status_code=400,
+                json={
+                    "data": {
+                        "validity": {
+                            "from": "2010-01-01T00:00:00+01:00",
+                            "to": "2019-01-01T00:00:00+01:00",
+                        },
+                    },
+                })
+
     def test_move_org_unit_should_fail_when_moving_root_unit(self):
         """Should fail validation when trying to move the root org unit"""
 

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -1291,7 +1291,7 @@ class Tests(util.LoRATestCase):
         )
 
     def test_move_org_unit(self):
-        # A generic example of editing an org unit
+        'Test successfully moving organisational units'
 
         self.load_sample_structures()
 
@@ -1540,7 +1540,7 @@ class Tests(util.LoRATestCase):
             json=req)
 
     def test_move_org_unit_wrong_org(self):
-        # A generic example of editing an org unit
+        'Verify that we cannot move a unit into another organisation'
 
         self.load_sample_structures()
 
@@ -1561,8 +1561,8 @@ class Tests(util.LoRATestCase):
         self.assertRequestResponse(
             '/service/ou/{}/edit'.format(org_unit_uuid),
             {
-                'description': 'Unit does not belong to the same '
-                'organisation.',
+                'description': 'Unit belongs to an organisation different '
+                'from the current one.',
                 'error': True,
                 'error_key': 'V_UNIT_OUTSIDE_ORG',
                 'org_unit_uuid': other_unit_uuid,
@@ -1584,7 +1584,7 @@ class Tests(util.LoRATestCase):
         )
 
     def test_move_org_autoparent(self):
-        # A generic example of editing an org unit
+        "Verify that we cannot create cycles when moving organisational units"
 
         self.load_sample_structures()
 

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -766,7 +766,7 @@ class Tests(util.LoRATestCase):
         self.assertRegistrationsEqual(expected, actual)
 
     def test_edit_org_unit_earlier_start(self):
-        # A generic example of editing an org unit
+        '''Test setting the start date to something earlier (#23182)'''
 
         self.load_sample_structures()
 

--- a/tests/test_integration_service.py
+++ b/tests/test_integration_service.py
@@ -488,10 +488,6 @@ class Tests(util.LoRATestCase):
                 'name': 'Overordnet Enhed',
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
-                'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
-                    'to': None,
-                },
                 'org': {
                     'name': 'Aarhus Universitet',
                     'user_key': 'AU',
@@ -525,10 +521,6 @@ class Tests(util.LoRATestCase):
                 'name': 'Overordnet Enhed',
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
-                'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
-                    'to': None,
-                },
                 'org': {
                     'name': 'Aarhus Universitet',
                     'user_key': 'AU',


### PR DESCRIPTION

make parent validity check more robust  …
This should ensure that a 'candidate parent' is properly valid:

1. It's valid at the exact time of the move.
2. Neither it, nor any parent, belongs to another organisation.
3. We are not creating a cycle.

Test #1 was failing, previously. In fixing I tried to make the
validation routine more robust and readable, adding #2 and
strengthening #3 to check for preëxisting cycles.

The root cause of bug #23182 was that the check didn't use
`common.is_reg_valid()` but instead rolled its own not-quite-as-robust
check, resulting in a move to a unit at an invalid date giving the
wrong error.
