### PR TITLE
#23172 proper termination error

### DIFF
--- a/mora/exceptions.py
+++ b/mora/exceptions.py
@@ -37,8 +37,6 @@ class ErrorCodes(Enum):
         400, "Org unit cannot be moved to one of its own child units"
     V_TERMINATE_UNIT_WITH_CHILDREN_OR_ROLES = \
         400, "Cannot terminate unit with active children and roles."
-    V_TERMINATE_UNIT_BEFORE_START_DATE = \
-        400, "Cannot terminate org unit before its starting date."
     V_DATE_OUTSIDE_ORG_UNIT_RANGE = \
         400, "Date range exceeds validity range of associated org unit."
     V_DATE_OUTSIDE_EMPL_RANGE = \

--- a/mora/service/orgunit.py
+++ b/mora/service/orgunit.py
@@ -738,7 +738,9 @@ def terminate_org_unit(unitid):
     c = lora.Connector(virkningfra=util.to_iso_time(date),
                        virkningtil='infinity')
 
-    validator.is_org_unit_termination_date_valid(unitid, date)
+    validator.is_date_range_in_org_unit_range(
+        unitid, date - util.MINIMAL_INTERVAL, date,
+    )
 
     children = c.organisationenhed.paged_get(
         get_one_orgunit,

--- a/mora/validator.py
+++ b/mora/validator.py
@@ -105,10 +105,14 @@ def _get_active_validity(reg: dict) -> typing.Mapping[str, str]:
 
 
 def is_date_range_in_org_unit_range(org_unit_uuid, valid_from, valid_to):
+    # query for the full range of effects; otherwise,
+    # _get_active_validity() won't return any useful data for time
+    # intervals predating the creation of the unit
     scope = lora.Connector(
         virkningfra=util.to_lora_time(util.NEGATIVE_INFINITY),
         virkningtil=util.to_lora_time(util.POSITIVE_INFINITY)
     ).organisationenhed
+
     org_unit = scope.get(org_unit_uuid)
 
     if not org_unit:

--- a/mora/validator.py
+++ b/mora/validator.py
@@ -260,12 +260,12 @@ def is_org_unit_termination_date_valid(unitid: str, end_date: datetime):
         if effect['tilstande']
                  ['organisationenhedgyldighed'][0]
                  ['gyldighed'] == 'Aktiv' and
-        start < end_date
+        start < end_date < end
     ]
 
     if not effects:
         raise exceptions.HTTPException(
-            exceptions.ErrorCodes.V_TERMINATE_UNIT_BEFORE_START_DATE,
+            exceptions.ErrorCodes.V_DATE_OUTSIDE_ORG_UNIT_RANGE,
         )
 
 

--- a/src/i18n/da/alerts.json
+++ b/src/i18n/da/alerts.json
@@ -31,7 +31,6 @@
     "V_NO_PERSON_FOR_CPR": "Ingen personer er fundet med det indtastet CPR nummer",
     "V_ORG_UNIT_MOVE_TO_CHILD": "Organisationsenheden kan ikke flyttes under dens egen underenheder",
     "V_ORIGINAL_REQUIRED": "Original er påkrævet",
-    "V_TERMINATE_UNIT_BEFORE_START_DATE": "Kan ikke afslutte organisationsenheden før dens start dato",
     "V_TERMINATE_UNIT_WITH_CHILDREN_OR_ROLES": "Kan ikke afslutte en enhed med aktive underenheder og roller"
   }
 }

--- a/src/organisation/MoOrganisationUnitWorkflows/MoOrganisationUnitTerminate.vue
+++ b/src/organisation/MoOrganisationUnitWorkflows/MoOrganisationUnitTerminate.vue
@@ -17,7 +17,11 @@
           v-model="org_unit"
           required
         />
-        <mo-date-picker :label="$t('input_fields.end_date')" v-model="terminate.validity.from" required/>
+        <mo-date-picker
+          :label="$t('input_fields.end_date')"
+          :valid-dates="validDates"
+          v-model="terminate.validity.from"
+          required/>
       </div>
       <div v-if="org_unit">
         <p>Følgende vil blive afsluttet for enheden:</p>
@@ -61,6 +65,10 @@
       }
     },
     computed: {
+      validDates () {
+        return this.org_unit ? this.org_unit.validity : {}
+      },
+
       formValid () {
         // loop over all contents of the fields object and check if they exist and valid.
         return Object.keys(this.fields).every(field => {

--- a/src/validators/DateInRange.js
+++ b/src/validators/DateInRange.js
@@ -15,8 +15,8 @@ export default {
   validate (value, range) {
     value = new Date(value)
 
-    let aboveMin = range.from ? value > range.from : true
-    let belowMax = range.to ? value < range.to : true
+    let aboveMin = range.from ? value > new Date(range.from) : true
+    let belowMax = range.to ? value < new Date(range.to) : true
 
     return aboveMin && belowMax
   }

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -1746,8 +1746,10 @@ class Tests(util.LoRATestCase):
             }
         }
 
-        self.request('/service/ou/{}/terminate'.format(unitid),
-                     json=payload)
+        self.assertRequestResponse(
+            '/service/ou/{}/terminate'.format(unitid),
+            unitid,
+            json=payload)
 
         self.assertRequestResponse(
             '/service/ou/{}'.format(unitid) +
@@ -1963,7 +1965,11 @@ class Tests(util.LoRATestCase):
                 'associated org unit.',
                 'error': True,
                 'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
-                'status': 400},
+                'status': 400,
+                'org_unit_uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
+                'valid_from': '2016-01-01T00:00:00+01:00',
+                'valid_to': None,
+            },
             status_code=400,
             json={
                 "validity": {
@@ -1981,7 +1987,11 @@ class Tests(util.LoRATestCase):
                 'associated org unit.',
                 'error': True,
                 'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
-                'status': 400},
+                'status': 400,
+                'org_unit_uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
+                'valid_from': '2016-01-01T00:00:00+01:00',
+                'valid_to': '2019-01-01T00:00:00+01:00',
+            },
             status_code=400,
             json={
                 "validity": {
@@ -2000,6 +2010,9 @@ class Tests(util.LoRATestCase):
                 'error': True,
                 'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                 'status': 400,
+                'org_unit_uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
+                'valid_from': '2016-01-01T00:00:00+01:00',
+                'valid_to': '2019-01-01T00:00:00+01:00',
             },
             status_code=400,
             json={

--- a/tests/test_integration_org_unit.py
+++ b/tests/test_integration_org_unit.py
@@ -1959,10 +1959,10 @@ class Tests(util.LoRATestCase):
                 "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
             ),
             {
-                'description': 'Cannot terminate org unit '
-                               'before its starting date.',
+                'description': 'Date range exceeds validity range of '
+                'associated org unit.',
                 'error': True,
-                'error_key': 'V_TERMINATE_UNIT_BEFORE_START_DATE',
+                'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                 'status': 400},
             status_code=400,
             json={
@@ -1970,4 +1970,42 @@ class Tests(util.LoRATestCase):
                     "from": "2000-01-01T00:00:00+01"
                 }
             },
+        )
+
+        self.assertRequestResponse(
+            '/service/ou/{}/terminate'.format(
+                "04c78fc2-72d2-4d02-b55f-807af19eac48",
+            ),
+            {
+                'description': 'Date range exceeds validity range of '
+                'associated org unit.',
+                'error': True,
+                'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
+                'status': 400},
+            status_code=400,
+            json={
+                "validity": {
+                    "from": "2100-01-01T00:00:00+01"
+                }
+            },
+        )
+
+        self.assertRequestResponse(
+            '/service/ou/{}/terminate'.format(
+                "04c78fc2-72d2-4d02-b55f-807af19eac48",
+            ),
+            {
+                'description': 'Date range exceeds validity range of '
+                'associated org unit.',
+                'error': True,
+                'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
+                'status': 400,
+            },
+            status_code=400,
+            json={
+                "validity": {
+                    "from": "2016-01-01 00:00:00+01"
+                }
+            },
+            message='No terminating on creation date!'
         )


### PR DESCRIPTION
This PR makes the error message for termination lie less; previously,
it'd claim the date was too early even if it was, in fact, too late.
Instead, we just re-use the message saying that the date is outside
the validity of the unit. Since we were doing that, I consolidated the
termination check into the validity check, and added a frontend
validation instead, since they're generally nicer and more immediate.