### PR TITLE
config: reset default proxying URL to localhost:5000, with override

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -12,11 +12,8 @@ module.exports = {
     assetsPublicPath: '/',
     proxyTable: {
       "/service": {
-        target: 'http://moxauth.local/service',
-        changeOrigin: true,
-        pathRewrite: {
-          '^/service': ''
-        }
+        target: process.env.BASE_URL || "http://localhost:5000/",
+        changeOrigin: true
       }
     },
 


### PR DESCRIPTION
You can now set `BASE_URL` to point to the preëexisting MO instance when
running the frontend dev server. It's similarly used when setting the
target of the TestCafé tests.