### PR TITLE
#23449 dummy cpr dates

### DIFF
--- a/mora/integrations/serviceplatformen.py
+++ b/mora/integrations/serviceplatformen.py
@@ -6,7 +6,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
+import datetime
 import random
+
 import service_person_stamdata_udvidet
 
 from requests import HTTPError
@@ -167,10 +169,19 @@ LAST_NAMES = [
     'Mortensen'
 ]
 
+# as of 2018, the oldest living Dane was born in 1908...
+EARLIEST_BIRTHDATE = util.parsedatetime('1901-01-01')
+
 
 def _get_citizen_stub(cpr):
     # Seed random with CPR number to ensure consistent output
     random.seed(cpr)
+
+    # disallow future CPR numbers and people too old to occur
+    # (interestingly, the latter also avoids weirdness related to
+    # Denmark using Copenhagen solar time in the 19th century...)
+    if not EARLIEST_BIRTHDATE < util.get_cpr_birthdate(cpr) < util.now():
+        raise KeyError('CPR not found')
 
     if (int(cpr[-1]) % 2) == 0:
         first_name = random.choice(FEMALE_FIRST_NAMES)

--- a/mora/integrations/serviceplatformen.py
+++ b/mora/integrations/serviceplatformen.py
@@ -57,7 +57,7 @@ MALE_FIRST_NAMES = [
     'Malthe',
     'Elias',
     'Christian',
-    'Mads'
+    'Mads',
     'Gustav',
     'Villads',
     'Tobias',
@@ -166,7 +166,7 @@ LAST_NAMES = [
     'Poulsen',
     'Johansen',
     'Møller',
-    'Mortensen'
+    'Mortensen',
 ]
 
 # as of 2018, the oldest living Dane was born in 1908...


### PR DESCRIPTION
This fixes, or rather, works around a few issues on our demo and test
servers. Unborn employees as well employees born in the 19th century
will almost certainly not occur in actual deployments, unless we get
extreme historic data. In that case, we'll fix whatever issues crop
up.

When testing, however, people often enter an arbitrary number, not
knowing that the CPR number actually corresponds to someone either
born in the future or in the century prior to last. Since this may
cause issues, we should simply report that nothing was found.