### PR TITLE
tests: skip TestCafé tests when requirements not satisfied

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mora",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OS2 Mennesker + Organisation 2.0",
   "author": "Magenta ApS <info@magenta.dk>",
   "private": true,

--- a/tests/test_cafe.py
+++ b/tests/test_cafe.py
@@ -12,8 +12,10 @@ import json
 import os
 import platform
 import subprocess
+import unittest
 
 from mora import util as mora_util
+from mora import app
 
 from . import util
 
@@ -25,6 +27,13 @@ class TestCafeTests(util.LiveLoRATestCase):
     JSON_REPORT_FILE = os.path.join(util.REPORTS_DIR, "testcafe.json")
     TEST_DIR = os.path.join(util.BASE_DIR, "e2e-tests")
 
+    TESTCAFE_COMMAND = os.path.join(util.BASE_DIR,
+                                    "node_modules", ".bin", "testcafe")
+
+    @unittest.skipUnless(
+        util.is_frontend_built() and os.path.isfile(TESTCAFE_COMMAND),
+        'frontend sources & TestCafé command required!',
+    )
     def test_with_testcafe(self):
         # Start the testing process
         print("----------------------")
@@ -49,8 +58,7 @@ class TestCafeTests(util.LiveLoRATestCase):
 
         process = subprocess.run(
             [
-                os.path.join(util.BASE_DIR,
-                             "node_modules", ".bin", "testcafe"),
+                self.TESTCAFE_COMMAND,
                 "'{} --no-sandbox'".format(browser),
                 self.TEST_DIR,
                 "-r", ','.join(["spec",

--- a/tests/util.py
+++ b/tests/util.py
@@ -36,6 +36,12 @@ BUILD_DIR = os.path.join(BASE_DIR, 'build')
 REPORTS_DIR = os.path.join(BUILD_DIR, 'reports')
 
 
+def is_frontend_built():
+    return os.path.isfile(
+        os.path.join(app.distdir, 'index.html'),
+    )
+
+
 def jsonfile_to_dict(path):
     """
     Reads JSON from resources folder and converts to Python dictionary


### PR DESCRIPTION
This should truly fix the LoRA testsuite, as it doesn't build the MO
frontend -- nor should it.