### PR TITLE
#23559: switch to using dates in REST API

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -13,6 +13,8 @@ Internal changes
 * #23559: REST API now uses and enforces ISO 8601 dates in all cases
   except history display. All ``from`` or ``to`` dates must either
   lack a timestamp or correspond to midnight, Central European time.
+* #23559: The ``terminate`` endpoints for employees as well as units
+  now read the date from the ``to`` field rather than ``from``.
 
 Bug fixes
 ---------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,9 +20,14 @@ Internal changes
 * #23992: Updated API documentation and README
 * #23993: Reorganisation of source code layout
 * #23994: Refactoring of frontend code
+* #23559: REST API now uses and enforces ISO 8601 dates in all cases
+  except history display. All ``from`` or ``to`` dates must either
+  lack a timestamp or correspond to midnight, European time.
 
 Bug fixes
 ---------
 
 * #24012: Fixed hotkey support
 * #24013: Fixed rename unit dialog not being populated correctly
+* #23559: Display end dates *inclusively*, so that the year ends 31
+  December rather than 1 January.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,6 +6,19 @@ New features
 
 * #22849: Implemented support for signed SAML AuthN Requests.
 
+Internal changes
+----------------
+
+* #23559: REST API now uses and enforces ISO 8601 dates in all cases
+  except history display. All ``from`` or ``to`` dates must either
+  lack a timestamp or correspond to midnight, Central European time.
+
+Bug fixes
+---------
+
+* #23559: Display end dates *inclusively*, so that the year ends 31
+  December rather than 1 January.
+
 Version 0.9.0, 2018-09-07
 =========================
 
@@ -20,14 +33,9 @@ Internal changes
 * #23992: Updated API documentation and README
 * #23993: Reorganisation of source code layout
 * #23994: Refactoring of frontend code
-* #23559: REST API now uses and enforces ISO 8601 dates in all cases
-  except history display. All ``from`` or ``to`` dates must either
-  lack a timestamp or correspond to midnight, European time.
 
 Bug fixes
 ---------
 
 * #24012: Fixed hotkey support
 * #24013: Fixed rename unit dialog not being populated correctly
-* #23559: Display end dates *inclusively*, so that the year ends 31
-  December rather than 1 January.

--- a/backend/mora/app.py
+++ b/backend/mora/app.py
@@ -53,14 +53,15 @@ def handle_invalid_usage(error):
     :return: JSON describing the problem and the apropriate status code.
     """
 
-    util.log_exception('unhandled exception')
+    if not isinstance(error, werkzeug.routing.RoutingException):
+        util.log_exception('unhandled exception')
 
     if not isinstance(error, werkzeug.exceptions.HTTPException):
         error = exceptions.HTTPException(
             description=str(error),
         )
 
-    return error.get_response()
+    return error.get_response(flask.request.environ)
 
 
 @app.route('/')

--- a/backend/mora/cli.py
+++ b/backend/mora/cli.py
@@ -12,6 +12,7 @@
 
 
 import base64
+import doctest
 import functools
 import importlib
 import json
@@ -191,6 +192,7 @@ def python(args):
 @click.option('--keyword', '-k', 'keywords', multiple=True,
               help='Only run or list tests matching the given keyword',)
 @click.argument('tests', nargs=-1)
+@flask.cli.with_appcontext
 def test(tests, quiet, verbose, minimox_dir, browser, do_list,
          keywords, xml_report, **kwargs):
     verbosity = 0 if quiet else verbose + 1
@@ -210,6 +212,10 @@ def test(tests, quiet, verbose, minimox_dir, browser, do_list,
             start_dir=os.path.join(backenddir, 'tests'),
             top_level_dir=os.path.join(backenddir),
         )
+
+    for module in sys.modules.values():
+        if getattr(module, '__file__', '').startswith(basedir):
+            suite.addTests(doctest.DocTestSuite(module))
 
     def expand_suite(suite):
         for member in suite:

--- a/backend/mora/common.py
+++ b/backend/mora/common.py
@@ -86,6 +86,7 @@ def inactivate_old_interval(old_from: str, old_to: str, new_from: str,
                             path: tuple) -> dict:
     """
     Create 'inactivation' updates based on two sets of from/to dates
+
     :param old_from: The old 'from' time, in ISO-8601
     :param old_to: The old 'to' time, in ISO-8601
     :param new_from: The new 'from' time, in ISO-8601

--- a/backend/mora/common.py
+++ b/backend/mora/common.py
@@ -553,10 +553,10 @@ def add_bruger_history_entry(employee_uuid, note: str):
 def convert_reg_to_history(reg):
     return {
         'user_ref': reg['brugerref'],
-        'from': util.to_frontend_time(
+        'from': util.to_iso_time(
             reg['fratidspunkt']['tidsstempeldatotid'],
         ),
-        'to': util.to_frontend_time(
+        'to': util.to_iso_time(
             reg['tiltidspunkt']['tidsstempeldatotid'],
         ),
         'life_cycle_code': reg['livscykluskode'],

--- a/backend/mora/service/address.py
+++ b/backend/mora/service/address.py
@@ -114,7 +114,7 @@ An example of reading the main two different types of addresses:
       "name": "8715 0000",
       "urn": "urn:magenta.dk:telefon:+4587150000",
       "validity": {
-        "from": "2016-01-01T00:00:00+01:00",
+        "from": "2016-01-01",
         "to": null
       }
     },
@@ -130,7 +130,7 @@ An example of reading the main two different types of addresses:
       "name": "Nordre Ringgade 1, 8000 Aarhus C",
       "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
       "validity": {
-        "from": "2016-01-01T00:00:00+01:00",
+        "from": "2016-01-01",
         "to": null
       }
     }

--- a/backend/mora/service/details.py
+++ b/backend/mora/service/details.py
@@ -130,8 +130,8 @@ def get_detail(type, id, function):
     .. sourcecode:: json
 
       {
-        "from": "2016-01-01T00:00:00+00:00",
-        "to": "2018-01-01T00:00:00+00:00",
+        "from": "2016-01-01",
+        "to": "2017-12-31",
       }
 
     :queryparam date at: Show details valid at this point in time,
@@ -191,7 +191,7 @@ def get_detail(type, id, function):
                 },
                 "uuid": "d000591f-8705-4324-897a-075e3623f37b",
                 "validity": {
-                    "from": "2017-01-01T00:00:00+01:00",
+                    "from": "2017-01-01",
                     "to": null
                 },
             }
@@ -241,8 +241,8 @@ def get_detail(type, id, function):
           },
           "uuid": "30cd25e1-b21d-46fe-b299-1c1265e9be66",
           "validity": {
-            "from": "2017-01-01T00:00:00+01:00",
-            "to": "2018-01-01T00:00:00+01:00"
+            "from": "2017-01-01",
+            "to": "2017-12-31"
           }
         }
       ]
@@ -257,7 +257,7 @@ def get_detail(type, id, function):
           "user_name": "Fedtmule",
           "uuid": "59c135c9-2b15-41cc-97c8-b5dff7180beb",
           "validity": {
-            "from": "2002-02-14T00:00:00+01:00",
+            "from": "2002-02-14",
             "to": null
           }
         }
@@ -277,7 +277,7 @@ def get_detail(type, id, function):
             "scope": "DAR"
           },
           "validity": {
-            "from": "2002-02-14T00:00:00+01:00",
+            "from": "2002-02-14",
             "to": null
           },
         },
@@ -293,7 +293,7 @@ def get_detail(type, id, function):
             "uuid": "c78eb6f7-8a9e-40b3-ac80-36b9f371c3e0"
           },
           "validity": {
-            "from": "2002-02-14T00:00:00+01:00",
+            "from": "2002-02-14",
             "to": null
           },
         },
@@ -309,7 +309,7 @@ def get_detail(type, id, function):
             "uuid": "c78eb6f7-8a9e-40b3-ac80-36b9f371c3e0"
           },
           "validity": {
-            "from": "2002-02-14T00:00:00+01:00",
+            "from": "2002-02-14",
             "to": null
           },
         }
@@ -344,8 +344,8 @@ def get_detail(type, id, function):
             "uuid": "da77153e-30f3-4dc2-a611-ee912a28d8aa"
           },
           "validity": {
-            "from": "2018-01-01T00:00:00+01:00",
-            "to": "2019-01-01T00:00:00+01:00"
+            "from": "2018-01-01",
+            "to": "2018-12-31"
           }
         }
       ]
@@ -402,7 +402,7 @@ def get_detail(type, id, function):
           ],
           "uuid": "05609702-977f-4869-9fb4-50ad74c6999a",
           "validity": {
-            "from": "2017-01-01T00:00:00+01:00",
+            "from": "2017-01-01",
             "to": null
           }
         }
@@ -635,8 +635,8 @@ def get_detail(type, id, function):
         }
 
         func[mapping.VALIDITY] = {
-            mapping.FROM: util.to_iso_time(start),
-            mapping.TO: util.to_iso_time(end),
+            mapping.FROM: util.to_iso_date(start),
+            mapping.TO: util.to_iso_date(end, is_end=True),
         }
         func[mapping.UUID] = funcid
 

--- a/backend/mora/service/employee.py
+++ b/backend/mora/service/employee.py
@@ -966,7 +966,8 @@ def edit_employee(employee_uuid):
 
 @blueprint.route('/e/<uuid:employee_uuid>/terminate', methods=['POST'])
 def terminate_employee(employee_uuid):
-    """Terminates an employee and all of his roles from a specified date.
+    """Terminates an employee and all of his roles beginning at a
+    specified date.
 
     .. :quickref: Employee; Terminate
 
@@ -974,8 +975,7 @@ def terminate_employee(employee_uuid):
 
     :param employee_uuid: The UUID of the employee to be terminated.
 
-    :<json string from: The date on which the termination should happen,
-                              in ISO 8601.
+    :<json string to: When the termination should occur, as an ISO 8601 date.
 
     **Example Request**:
 
@@ -983,11 +983,12 @@ def terminate_employee(employee_uuid):
 
       {
         "validity": {
-          "from": "2015-12-31"
+          "to": "2015-12-31"
         }
       }
+
     """
-    date = util.get_valid_from(flask.request.get_json(), is_end=True)
+    date = util.get_valid_to(flask.request.get_json())
 
     # Org funks
     types = (

--- a/backend/mora/service/employee.py
+++ b/backend/mora/service/employee.py
@@ -216,8 +216,8 @@ def create_employee_relation(employee_uuid):
     .. sourcecode:: json
 
       {
-        "from": "2016-01-01T00:00:00+00:00",
-        "to": "2018-01-01T00:00:00+00:00",
+        "from": "2016-01-01",
+        "to": "2017-12-31",
       }
 
     Request payload contains a list of creation objects, each differentiated
@@ -250,8 +250,8 @@ def create_employee_relation(employee_uuid):
             "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
           },
           "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
-              "to": "2018-01-01T00:00:00+00:00"
+              "from": "2016-01-01",
+              "to": "2017-12-31"
           }
         }
       ]
@@ -295,8 +295,8 @@ def create_employee_relation(employee_uuid):
             }
           },
           "validity": {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00"
+            "from": "2016-01-01",
+            "to": "2017-12-31"
           }
         }
       ]
@@ -317,7 +317,7 @@ def create_employee_relation(employee_uuid):
                   "uuid": "59c135c9-2b15-41cc-97c8-b5dff7180beb"
               },
               "validity": {
-                  "from": "2017-12-01T00:00:00+01",
+                  "from": "2017-12-01",
                   "to": null
               }
           }
@@ -346,8 +346,8 @@ def create_employee_relation(employee_uuid):
             "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
           },
           "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
-              "to": "2018-01-01T00:00:00+00:00"
+              "from": "2016-01-01",
+              "to": "2017-12-31"
           }
         }
       ]
@@ -397,8 +397,8 @@ def create_employee_relation(employee_uuid):
             }
           },
           "validity": {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00"
+            "from": "2016-01-01",
+            "to": "2017-12-31"
           }
         }
       ]
@@ -422,8 +422,8 @@ def create_employee_relation(employee_uuid):
             "uuid": "62ec821f-4179-4758-bfdf-134529d186e9"
           },
           "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
-              "to": "2018-01-01T00:00:00+00:00"
+              "from": "2016-01-01",
+              "to": "2017-12-31"
           },
         }
       ]
@@ -455,8 +455,8 @@ def create_employee_relation(employee_uuid):
           },
           "type": "address",
           "validity": {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00"
+            "from": "2016-01-01",
+            "to": "2017-12-31"
           }
         }
       ]
@@ -517,8 +517,8 @@ def edit_employee(employee_uuid):
     .. sourcecode:: json
 
       {
-        "from": "2016-01-01T00:00:00+00:00",
-        "to": "2018-01-01T00:00:00+00:00"
+        "from": "2016-01-01",
+        "to": "2017-12-31"
       }
 
     Request payload contains a list of edit objects, each differentiated
@@ -558,8 +558,8 @@ def edit_employee(employee_uuid):
           "uuid": "de9e7513-1934-481f-b8c8-45336387e9cb",
           "original": {
             "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
-              "to": "2018-01-01T00:00:00+00:00"
+              "from": "2016-01-01",
+              "to": "2017-12-31"
             },
             "job_function": {
               "uuid": "5b56432c-f289-4d81-a328-b878ea0a4e1b"
@@ -573,8 +573,8 @@ def edit_employee(employee_uuid):
           },
           "data": {
             "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
-              "to": "2019-01-01T00:00:00+00:00"
+              "from": "2016-01-01",
+              "to": "2018-12-31"
             },
             "job_function": {
               "uuid": "5b56432c-f289-4d81-a328-b878ea0a4e1b"
@@ -619,8 +619,8 @@ def edit_employee(employee_uuid):
           "uuid": "de9e7513-1934-481f-b8c8-45336387e9cb",
           "original": {
             "validity": {
-                "from": "2016-01-01T00:00:00+00:00",
-                "to": "2018-01-01T00:00:00+00:00"
+                "from": "2016-01-01",
+                "to": "2016-12-31"
             },
             "job_function": {
               "uuid": "5b56432c-f289-4d81-a328-b878ea0a4e1b"
@@ -644,8 +644,8 @@ def edit_employee(employee_uuid):
           },
           "data": {
             "validity": {
-                "from": "2016-01-01T00:00:00+00:00",
-                "to": "2019-01-01T00:00:00+00:00"
+                "from": "2016-01-01",
+                "to": "2018-12-31"
             },
             "job_function": {
               "uuid": "5b56432c-f289-4d81-a328-b878ea0a4e1b"
@@ -683,14 +683,14 @@ def edit_employee(employee_uuid):
             "user_name": "Fedtmule",
             "uuid": "00000000-0000-0000-0000-000000000000",
             "validity": {
-              "from": "2002-02-14T00:00:00+01:00",
+              "from": "2002-02-14",
               "to": null
             }
           },
           "data": {
             "uuid": "11111111-1111-1111-1111-111111111111",
             "validity": {
-              "to": "2020-01-01T00:00:00+01:00"
+              "to": "2019-12-31"
             }
           }
         }
@@ -728,8 +728,8 @@ def edit_employee(employee_uuid):
           "uuid": "de9e7513-1934-481f-b8c8-45336387e9cb",
           "original": {
             "validity": {
-                "from": "2016-01-01T00:00:00+00:00",
-                "to": "2018-01-01T00:00:00+00:00"
+                "from": "2016-01-01",
+                "to": "2017-12-31"
             },
             "role_type": {
               "uuid": "743a6448-2b0b-48cf-8a2e-bf938a6181ee"
@@ -740,8 +740,8 @@ def edit_employee(employee_uuid):
           },
           "data": {
             "validity": {
-                "from": "2016-01-01T00:00:00+00:00",
-                "to": "2019-01-01T00:00:00+00:00"
+                "from": "2016-01-01",
+                "to": "2018-12-31"
             },
             "role_type": {
               "uuid": "eee27f47-8355-4ae2-b223-0ee0fdad81be"
@@ -781,8 +781,8 @@ def edit_employee(employee_uuid):
           "uuid": "de9e7513-1934-481f-b8c8-45336387e9cb",
           "original": {
             "validity": {
-                "from": "2016-01-01T00:00:00+00:00",
-                "to": "2018-01-01T00:00:00+00:00"
+                "from": "2016-01-01",
+                "to": "2017-12-31"
             },
             "leave_type": {
               "uuid": "743a6448-2b0b-48cf-8a2e-bf938a6181ee"
@@ -790,8 +790,8 @@ def edit_employee(employee_uuid):
           },
           "data": {
             "validity": {
-                "from": "2016-01-01T00:00:00+00:00",
-                "to": "2019-01-01T00:00:00+00:00"
+                "from": "2016-01-01",
+                "to": "2018-12-31"
             },
             "leave_type": {
               "uuid": "eee27f47-8355-4ae2-b223-0ee0fdad81be"
@@ -861,14 +861,14 @@ def edit_employee(employee_uuid):
                 }
               },
               "validity": {
-                  "from": "2016-01-01T00:00:00+00:00",
-                  "to": "2018-01-01T00:00:00+00:00"
+                  "from": "2016-01-01",
+                  "to": "2017-12-31"
               }
           },
           "data": {
             "validity": {
-                "from": "2016-01-01T00:00:00+00:00",
-                "to": "2019-01-01T00:00:00+00:00"
+                "from": "2016-01-01",
+                "to": "2018-12-31"
             },
             "manager_type": {
               "uuid": "eee27f47-8355-4ae2-b223-0ee0fdad81be"
@@ -916,8 +916,8 @@ def edit_employee(employee_uuid):
           },
           "type": "address",
           "validity": {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00"
+            "from": "2016-01-01",
+            "to": "2017-12-31"
           }
         }
       ]
@@ -983,11 +983,11 @@ def terminate_employee(employee_uuid):
 
       {
         "validity": {
-          "from": "2016-01-01T00:00:00+00:00"
+          "from": "2015-12-31"
         }
       }
     """
-    date = util.get_valid_from(flask.request.get_json())
+    date = util.get_valid_from(flask.request.get_json(), is_end=True)
 
     # Org funks
     types = (

--- a/backend/mora/service/itsystem.py
+++ b/backend/mora/service/itsystem.py
@@ -116,8 +116,8 @@ class ITSystems(common.AbstractRelationDetail):
         .. sourcecode:: json
 
           {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00",
+            "from": "2016-01-01",
+            "to": "2017-12-31",
           }
 
         :<jsonarr string name:
@@ -147,8 +147,8 @@ class ITSystems(common.AbstractRelationDetail):
               "user_key": "LoRa",
               "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
               "validity": {
-                "from": "2016-01-01T00:00:00+01:00",
-                "to": "2018-01-01T00:00:00+01:00"
+                "from": "2016-01-01",
+                "to": "2017-12-31"
               },
             },
             {
@@ -158,7 +158,7 @@ class ITSystems(common.AbstractRelationDetail):
               "user_key": "AD",
               "uuid": "59c135c9-2b15-41cc-97c8-b5dff7180beb",
               "validity": {
-                "from": "2002-02-14T00:00:00+01:00",
+                "from": "2002-02-14",
                 "to": null
               },
             }

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -842,7 +842,7 @@ def terminate_org_unit(unitid):
     c = lora.Connector(effective_date=util.to_iso_date(date))
 
     validator.is_date_range_in_org_unit_range(
-        unitid, date - util.ONE_DAY, date,
+        unitid, date - util.MINIMAL_INTERVAL, date,
     )
 
     children = c.organisationenhed.paged_get(

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -839,8 +839,7 @@ def terminate_org_unit(unitid):
     """
     date = util.get_valid_from(flask.request.get_json(), is_end=True)
 
-    c = lora.Connector(virkningfra=util.to_iso_date(date),
-                       virkningtil='infinity')
+    c = lora.Connector(effective_date=util.to_iso_date(date))
 
     validator.is_date_range_in_org_unit_range(
         unitid, date - util.ONE_DAY, date,

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -825,7 +825,7 @@ def terminate_org_unit(unitid):
 
       {
         "validity": {
-          "from": "2015-12-31"
+          "to": "2015-12-31"
         }
       }
 
@@ -858,7 +858,7 @@ def terminate_org_unit(unitid):
       }
 
     """
-    date = util.get_valid_from(flask.request.get_json(), is_end=True)
+    date = util.get_valid_to(flask.request.get_json())
 
     c = lora.Connector(effective_date=util.to_iso_date(date))
 

--- a/backend/mora/service/orgunit.py
+++ b/backend/mora/service/orgunit.py
@@ -67,8 +67,8 @@ class OrgUnit(common.AbstractRelationDetail):
             get_one_orgunit(
                 c, objid, effect, details=UnitDetails.FULL,
                 validity={
-                    mapping.FROM: util.to_iso_time(start),
-                    mapping.TO: util.to_iso_time(end),
+                    mapping.FROM: util.to_iso_date(start),
+                    mapping.TO: util.to_iso_date(end, is_end=True),
                 },
             )
             for start, end, effect in c.organisationenhed.get_effects(
@@ -269,8 +269,8 @@ def get_children(type, parentid):
           "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
           "child_count": 2,
           "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
-              "to": "2019-01-01T00:00:00+00:00"
+              "from": "2016-01-01",
+              "to": "2018-12-31"
           }
         },
         {
@@ -279,8 +279,8 @@ def get_children(type, parentid):
           "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
           "child_count": 0,
           "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
-              "to": "2019-01-01T00:00:00+00:00"
+              "from": "2016-01-01",
+              "to": "2018-12-31"
           }
         }
       ]
@@ -359,13 +359,13 @@ def get_orgunit(unitid):
           "user_key": "hist",
           "uuid": "da77153e-30f3-4dc2-a611-ee912a28d8aa",
           "validity": {
-            "from": "2016-01-01T00:00:00+01:00",
-            "to": "2019-01-01T00:00:00+01:00"
+            "from": "2016-01-01",
+            "to": "2018-12-31"
           }
         },
         "validity": {
-          "from": "2016-01-01T00:00:00+01:00",
-          "to": "2019-01-01T00:00:00+01:00"
+          "from": "2016-01-01",
+          "to": "2018-12-31"
         }
       }
 
@@ -420,7 +420,7 @@ def list_orgunits(orgid):
             "user_key": "samf",
             "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
             "validity": {
-              "from": "2017-01-01T00:00:00+01:00",
+              "from": "2017-01-01",
               "to": null
             }
           }
@@ -489,7 +489,7 @@ def create_org_unit():
           "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
         },
         "validity": {
-          "from": "2016-01-01T00:00:00+00:00",
+          "from": "2016-01-01",
           "to": null
         },
         "addresses": [{
@@ -502,8 +502,8 @@ def create_org_unit():
             "uuid": "e34d4426-9845-4c72-b31e-709be85d6fa2"
           },
           "validity": {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00"
+            "from": "2016-01-01",
+            "to": "2017-12-31"
           }
         }]
       }
@@ -621,14 +621,14 @@ def edit_org_unit(unitid):
               "uuid": "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
             },
             "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
+              "from": "2016-01-01",
               "to": null
             }
           },
           "data": {
             "name": "Vaffelhuset",
             "validity": {
-              "from": "2016-01-01T00:00:00+00:00",
+              "from": "2016-01-01",
             }
           }
         }
@@ -673,8 +673,8 @@ def edit_org_unit(unitid):
           },
           "type": "address",
           "validity": {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00"
+            "from": "2016-01-01",
+            "to": "2017-12-31"
           }
         }
       ]
@@ -720,8 +720,8 @@ def create_org_unit_relation(unitid):
     .. sourcecode:: json
 
       {
-        "from": "2016-01-01T00:00:00+00:00",
-        "to": "2018-01-01T00:00:00+00:00",
+        "from": "2016-01-01",
+        "to": "2017-12-31",
       }
 
     Request payload contains a list of creation objects, each differentiated
@@ -755,8 +755,8 @@ def create_org_unit_relation(unitid):
           },
           "type": "address",
           "validity": {
-            "from": "2016-01-01T00:00:00+00:00",
-            "to": "2018-01-01T00:00:00+00:00"
+            "from": "2016-01-01",
+            "to": "2017-12-31"
           }
         }
       ]
@@ -804,7 +804,7 @@ def terminate_org_unit(unitid):
 
       {
         "validity": {
-          "from": "2016-01-01T00:00:00+00:00"
+          "from": "2015-12-31"
         }
       }
 
@@ -837,13 +837,13 @@ def terminate_org_unit(unitid):
       }
 
     """
-    date = util.get_valid_from(flask.request.get_json())
+    date = util.get_valid_from(flask.request.get_json(), is_end=True)
 
-    c = lora.Connector(virkningfra=util.to_iso_time(date),
+    c = lora.Connector(virkningfra=util.to_iso_date(date),
                        virkningtil='infinity')
 
     validator.is_date_range_in_org_unit_range(
-        unitid, date - util.MINIMAL_INTERVAL, date,
+        unitid, date - util.ONE_DAY, date,
     )
 
     children = c.organisationenhed.paged_get(

--- a/backend/mora/util.py
+++ b/backend/mora/util.py
@@ -162,6 +162,8 @@ def from_iso_time(s):
 
     if not dt.tzinfo:
         dt = dt.replace(tzinfo=DEFAULT_TIMEZONE)
+    else:
+        dt = dt.astimezone(DEFAULT_TIMEZONE)
 
     return dt
 

--- a/backend/mora/util.py
+++ b/backend/mora/util.py
@@ -166,19 +166,6 @@ def from_iso_time(s):
     return dt
 
 
-def to_frontend_time(s):
-    dt = parsedatetime(s)
-
-    if dt == POSITIVE_INFINITY:
-        return 'infinity'
-    elif dt == NEGATIVE_INFINITY:
-        return '-infinity'
-    elif dt and dt.time().replace(tzinfo=None) == datetime.time():
-        return unparsedate(dt.date())
-    else:
-        return dt.isoformat()
-
-
 def now() -> datetime.datetime:
     '''Get the current time, localized to the current time zone.'''
     return datetime.datetime.now().replace(tzinfo=DEFAULT_TIMEZONE)

--- a/backend/mora/validator.py
+++ b/backend/mora/validator.py
@@ -53,7 +53,8 @@ def _is_date_range_valid(parent: typing.Union[dict, str],
         elif start != previous_end:
             # non-consecutive chunk - so not valid for that time
             return False
-        elif start >= enddate or end <= startdate:
+        elif start >= enddate or end < startdate:
+            previous_end = end
             continue
 
         vs = effect['tilstande'][gyldighed_key]

--- a/backend/mora/validator.py
+++ b/backend/mora/validator.py
@@ -78,7 +78,7 @@ def _get_active_validity(reg: dict) -> typing.Mapping[str, str]:
     '''
 
     return {
-        'valid_from': util.to_iso_time(
+        'valid_from': util.to_iso_date(
             min(
                 (
                     util.get_effect_from(state)
@@ -88,7 +88,7 @@ def _get_active_validity(reg: dict) -> typing.Mapping[str, str]:
                 default=util.NEGATIVE_INFINITY,
             ),
         ),
-        'valid_to': util.to_iso_time(
+        'valid_to': util.to_iso_date(
             max(
                 (
                     util.get_effect_to(state)
@@ -97,6 +97,7 @@ def _get_active_validity(reg: dict) -> typing.Mapping[str, str]:
                 ),
                 default=util.POSITIVE_INFINITY,
             ),
+            is_end=True,
         ),
     }
 
@@ -125,8 +126,8 @@ def is_date_range_in_org_unit_range(org_unit_uuid, valid_from, valid_to):
         raise exceptions.HTTPException(
             exceptions.ErrorCodes.V_DATE_OUTSIDE_ORG_UNIT_RANGE,
             org_unit_uuid=org_unit_uuid,
-            wanted_valid_from=util.to_iso_time(valid_from),
-            wanted_valid_to=util.to_iso_time(valid_to),
+            wanted_valid_from=util.to_iso_date(valid_from),
+            wanted_valid_to=util.to_iso_date(valid_to, is_end=True),
             **_get_active_validity(org_unit),
         )
 

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -4,7 +4,6 @@ Flask-Testing>=0.6.2
 freezegun>=0.3.9
 requests-mock>=1.3.0
 pycodestyle>=2.3.1,<2.4.0
-selenium>=3.4.3
 coverage>=4.4.1
 termcolor>=1.1.0
 unittest-xml-reporting>=2.2.0

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -5,7 +5,6 @@ exclude =
         .git,
         node_modules,
         venv*,
-        tests/test_selenium.py
         mox
 
 #max-complexity = 20

--- a/backend/tests/fixtures/very-edited-unit.json
+++ b/backend/tests/fixtures/very-edited-unit.json
@@ -1,0 +1,182 @@
+{
+  "attributter": {
+    "organisationenhedegenskaber": [
+      {
+        "brugervendtnoegle": "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+        "enhedsnavn": "AlexTest",
+        "virkning": {
+          "from": "2018-09-01 00:00:00+02",
+          "from_included": true,
+          "to": "infinity",
+          "to_included": false
+        }
+      },
+      {
+        "brugervendtnoegle": "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+        "enhedsnavn": "AlexTestah",
+        "virkning": {
+          "from": "2018-08-01 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-23 00:00:00+02",
+          "to_included": false
+        }
+      },
+      {
+        "brugervendtnoegle": "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+        "enhedsnavn": "AlexTestikah",
+        "virkning": {
+          "from": "2018-08-23 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-24 00:00:00+02",
+          "to_included": false
+        }
+      },
+      {
+        "brugervendtnoegle": "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+        "enhedsnavn": "AlexTestikah",
+        "virkning": {
+          "from": "2018-08-24 00:00:00+02",
+          "from_included": true,
+          "to": "2018-09-01 00:00:00+02",
+          "to_included": false
+        }
+      }
+    ]
+  },
+  "note": "Rediger organisationsenhed",
+  "relationer": {
+    "adresser": [
+      {
+        "objekttype": "4e337d8e-1fd2-4449-8110-e0c8a22958ed",
+        "uuid": "9da8eb2b-e6f8-4724-ab04-3fef21eca31c",
+        "virkning": {
+          "from": "2018-08-05 00:00:00+02",
+          "from_included": true,
+          "to": "infinity",
+          "to_included": false
+        }
+      },
+      {
+        "objekttype": "1d1d3711-5af4-4084-99b3-df2b8752fdec",
+        "urn": "urn:magenta.dk:telefon:+4512946764",
+        "virkning": {
+          "from": "2018-08-03 00:00:00+02",
+          "from_included": true,
+          "to": "infinity",
+          "to_included": false
+        }
+      },
+      {
+        "objekttype": "e34d4426-9845-4c72-b31e-709be85d6fa2",
+        "urn": "urn:magenta.dk:ean:1234567890876",
+        "virkning": {
+          "from": "2018-08-01 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-31 00:00:00+02",
+          "to_included": false
+        }
+      },
+      {
+        "objekttype": "4e337d8e-1fd2-4449-8110-e0c8a22958ed",
+        "uuid": "9024c8c9-aec8-49c9-857f-f7dd13a38fbc",
+        "virkning": {
+          "from": "2018-08-01 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-31 00:00:00+02",
+          "to_included": false
+        }
+      }
+    ],
+    "enhedstype": [
+      {
+        "uuid": "32547559-cfc1-4d97-94c6-70b192eff825",
+        "virkning": {
+          "from": "2018-08-01 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-24 00:00:00+02",
+          "to_included": false
+        }
+      },
+      {
+        "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6",
+        "virkning": {
+          "from": "2018-08-24 00:00:00+02",
+          "from_included": true,
+          "to": "infinity",
+          "to_included": false
+        }
+      }
+    ],
+    "overordnet": [
+      {
+        "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
+        "virkning": {
+          "from": "2018-08-24 00:00:00+02",
+          "from_included": true,
+          "to": "infinity",
+          "to_included": false
+        }
+      },
+      {
+        "uuid": "2874e1dc-85e6-4269-823a-e1125484dfd3",
+        "virkning": {
+          "from": "2018-08-01 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-24 00:00:00+02",
+          "to_included": false
+        }
+      }
+    ],
+    "tilhoerer": [
+      {
+        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62",
+        "virkning": {
+          "from": "2018-08-01 00:00:00+02",
+          "from_included": true,
+          "to": "infinity",
+          "to_included": false
+        }
+      }
+    ]
+  },
+  "tilstande": {
+    "organisationenhedgyldighed": [
+      {
+        "gyldighed": "Aktiv",
+        "virkning": {
+          "from": "2018-08-01 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-23 00:00:00+02",
+          "to_included": false
+        }
+      },
+      {
+        "gyldighed": "Aktiv",
+        "virkning": {
+          "from": "2018-08-23 00:00:00+02",
+          "from_included": true,
+          "to": "2018-08-24 00:00:00+02",
+          "to_included": false
+        }
+      },
+      {
+        "gyldighed": "Aktiv",
+        "virkning": {
+          "from": "2018-08-24 00:00:00+02",
+          "from_included": true,
+          "to": "2018-09-01 00:00:00+02",
+          "to_included": false
+        }
+      },
+      {
+        "gyldighed": "Aktiv",
+        "virkning": {
+          "from": "2018-09-01 00:00:00+02",
+          "from_included": true,
+          "to": "infinity",
+          "to_included": false
+        }
+      }
+    ]
+  }
+}

--- a/backend/tests/test_cafe.py
+++ b/backend/tests/test_cafe.py
@@ -34,6 +34,10 @@ class TestCafeTests(util.LiveLoRATestCase):
         util.is_frontend_built() and os.path.isfile(TESTCAFE_COMMAND),
         'frontend sources & TestCafé command required!',
     )
+    @unittest.skipIf(
+        'SKIP_TESTCAFE' in os.environ,
+        'TestCafé disabled by $SKIP_TESTCAFE!',
+    )
     def test_with_testcafe(self):
         # Start the testing process
         print("----------------------")

--- a/backend/tests/test_create_orgfunk.py
+++ b/backend/tests/test_create_orgfunk.py
@@ -21,8 +21,8 @@ class TestCreateOrgFunk(unittest.TestCase):
                     'funktionsnavn': 'funktionsnavn',
                     'brugervendtnoegle': 'brugervendtnoegle',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }]
             },
@@ -32,15 +32,15 @@ class TestCreateOrgFunk(unittest.TestCase):
                     {
                         'uuid': 'a30f5f68-9c0d-44e9-afc9-04e58f52dfec',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     },
                     {
                         'uuid': '3f2e320e-d265-4480-a4f6-b92e40cf91b3',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     }
                 ],
@@ -48,45 +48,45 @@ class TestCreateOrgFunk(unittest.TestCase):
                     {
                         'uuid': '0b745aa2-6cf8-44a7-a7bc-9b7f75ce0ad6',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     },
                     {
                         'uuid': 'c20a1d60-33df-4dd3-9509-125e66b124eb',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     }
                 ],
                 'organisatoriskfunktionstype': [{
                     'uuid': '62ec821f-4179-4758-bfdf-134529d186e9',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }],
                 'tilknyttedeorganisationer': [{
                     'uuid': 'f494ad89-039d-478e-91f2-a63566554bd6',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }],
                 'opgaver': [
                     {
                         'uuid': '3ef81e52-0deb-487d-9d0e-a69bbe0277d8',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     },
                     {
                         'uuid': '8017363b-e836-41c1-8511-2287d8fbc8a2',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     }
                 ]
@@ -94,8 +94,8 @@ class TestCreateOrgFunk(unittest.TestCase):
             'tilstande': {
                 'organisationfunktiongyldighed': [{
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     },
                     'gyldighed': 'Aktiv'
                 }]
@@ -103,8 +103,8 @@ class TestCreateOrgFunk(unittest.TestCase):
         }
 
         funktionsnavn = "funktionsnavn"
-        valid_from = "2016-01-01T00:00:00+00:00"
-        valid_to = "2018-01-01T00:00:00+00:00"
+        valid_from = "2016-01-01T00:00:00+01:00"
+        valid_to = "2018-01-01T00:00:00+01:00"
         brugervendtnoegle = "brugervendtnoegle"
         tilknyttedebrugere = ['0b745aa2-6cf8-44a7-a7bc-9b7f75ce0ad6',
                               'c20a1d60-33df-4dd3-9509-125e66b124eb']
@@ -143,8 +143,8 @@ class TestCreateOrgFunk(unittest.TestCase):
                     'funktionsnavn': 'funktionsnavn',
                     'brugervendtnoegle': 'brugervendtnoegle',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }]
             },
@@ -153,23 +153,23 @@ class TestCreateOrgFunk(unittest.TestCase):
                 'tilknyttedebrugere': [{
                     'uuid': '0b745aa2-6cf8-44a7-a7bc-9b7f75ce0ad6',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }],
                 'tilknyttedeorganisationer': [{
                     'uuid': 'f494ad89-039d-478e-91f2-a63566554bd6',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }],
             },
             'tilstande': {
                 'organisationfunktiongyldighed': [{
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     },
                     'gyldighed': 'Aktiv'
                 }]
@@ -177,8 +177,8 @@ class TestCreateOrgFunk(unittest.TestCase):
         }
 
         funktionsnavn = "funktionsnavn"
-        valid_from = "2016-01-01T00:00:00+00:00"
-        valid_to = "2018-01-01T00:00:00+00:00"
+        valid_from = "2016-01-01T00:00:00+01:00"
+        valid_to = "2018-01-01T00:00:00+01:00"
         brugervendtnoegle = "brugervendtnoegle"
         tilknyttedebrugere = ['0b745aa2-6cf8-44a7-a7bc-9b7f75ce0ad6']
         tilknyttedeorganisationer = ["f494ad89-039d-478e-91f2-a63566554bd6"]

--- a/backend/tests/test_create_orgunit.py
+++ b/backend/tests/test_create_orgunit.py
@@ -21,8 +21,8 @@ class TestCreateOrgFunk(unittest.TestCase):
                     'enhedsnavn': 'enhedsnavn',
                     'brugervendtnoegle': 'brugervendtnoegle',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }]
             },
@@ -32,45 +32,45 @@ class TestCreateOrgFunk(unittest.TestCase):
                     {
                         "uuid": "3491846c-ca4f-4339-a447-526fb0bfce55",
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     },
                     {
                         "uuid": "aff9cef9-52be-46a0-9db7-14b4bb259cce",
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     }
                 ],
                 'overordnet': [{
                     'uuid': '47145ce1-c702-42c2-a88e-011eb09d250f',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }],
                 'tilhoerer': [{
                     'uuid': 'e0f7a6f7-2a76-45dc-b326-d49b4bb2c2b9',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }],
                 'enhedstype': [{
                     'uuid': '28d3c9f6-cce0-4649-bf73-ccbb78dc04e4',
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     }
                 }],
             },
             'tilstande': {
                 'organisationenhedgyldighed': [{
                     'virkning': {
-                        'from': '2016-01-01T00:00:00+00:00',
-                        'to': '2018-01-01T00:00:00+00:00'
+                        'from': '2016-01-01T00:00:00+01:00',
+                        'to': '2018-01-01T00:00:00+01:00'
                     },
                     'gyldighed': 'Aktiv'
                 }]
@@ -78,8 +78,8 @@ class TestCreateOrgFunk(unittest.TestCase):
         }
 
         enhedsnavn = "enhedsnavn"
-        valid_from = "2016-01-01T00:00:00+00:00"
-        valid_to = "2018-01-01T00:00:00+00:00"
+        valid_from = "2016-01-01T00:00:00+01:00"
+        valid_to = "2018-01-01T00:00:00+01:00"
         brugervendtnoegle = "brugervendtnoegle"
         adresser = [
             {

--- a/backend/tests/test_integration_address.py
+++ b/backend/tests/test_integration_address.py
@@ -124,7 +124,7 @@ class Writing(util.LoRATestCase):
                 'name': 'bruger@example.com',
                 'urn': 'urn:mailto:bruger@example.com',
                 'validity': {
-                    'from': '1934-06-09T00:00:00+01:00',
+                    'from': '1934-06-09',
                     'to': None,
                 },
             }
@@ -171,7 +171,7 @@ class Writing(util.LoRATestCase):
                     "address_type": ean_class,
                     "value": '1234567890',
                     "validity": {
-                        "from": "2013-01-01T00:00:00+01:00",
+                        "from": "2013-01-01",
                         "to": None,
                     },
                 },
@@ -215,7 +215,7 @@ class Writing(util.LoRATestCase):
                 'name': '1234567890',
                 'urn': 'urn:magenta.dk:ean:1234567890',
                 'validity': {
-                    'from': '2013-01-01T00:00:00+01:00',
+                    'from': '2013-01-01',
                     'to': None,
                 },
             },
@@ -248,7 +248,7 @@ class Writing(util.LoRATestCase):
                     "address_type": email_class,
                     "value": "hest@example.com",
                     "validity": {
-                        "from": "2014-01-01T00:00:00+01",
+                        "from": "2014-01-01",
                     },
                 },
                 {
@@ -256,7 +256,7 @@ class Writing(util.LoRATestCase):
                     "address_type": address_class,
                     "uuid": "ae95777c-7ec1-4039-8025-e2ecce5099fb",
                     "validity": {
-                        "from": "2015-01-01T00:00:00+01",
+                        "from": "2015-01-01",
                     },
                 },
                 {
@@ -264,7 +264,7 @@ class Writing(util.LoRATestCase):
                     "address_type": phone_class,
                     "value": '3336 9696',
                     "validity": {
-                        "from": "2016-01-01T00:00:00+01",
+                        "from": "2016-01-01",
                     },
                 },
             ],
@@ -277,7 +277,7 @@ class Writing(util.LoRATestCase):
                 'name': 'hest@example.com',
                 'urn': 'urn:mailto:hest@example.com',
                 'validity': {
-                    'from': '2014-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2014-01-01', 'to': None,
                 },
             },
             {
@@ -287,7 +287,7 @@ class Writing(util.LoRATestCase):
                 'name': 'Rådhuspladsen 2, 4., 8000 Aarhus C',
                 'uuid': 'ae95777c-7ec1-4039-8025-e2ecce5099fb',
                 'validity': {
-                    'from': '2015-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2015-01-01', 'to': None,
                 },
             },
             {
@@ -296,7 +296,7 @@ class Writing(util.LoRATestCase):
                 'name': '33369696',
                 'urn': 'urn:magenta.dk:telefon:+4533369696',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
             },
         ]
@@ -430,7 +430,7 @@ class Writing(util.LoRATestCase):
                     "address_type": address_class,
                     "uuid": '606cf42e-9dc2-4477-bf70-594830fcbdec',
                     "validity": {
-                        "from": "2013-01-01T00:00:00+01:00",
+                        "from": "2013-01-01",
                         "to": None,
                     },
                 },
@@ -452,7 +452,7 @@ class Writing(util.LoRATestCase):
                     },
                     'validity': {
                         'to': None,
-                        'from': '2013-01-01T00:00:00+01:00',
+                        'from': '2013-01-01',
                     },
                     'uuid': '606cf42e-9dc2-4477-bf70-594830fcbdec',
                 }
@@ -497,7 +497,7 @@ class Writing(util.LoRATestCase):
                     'name': 'bruger@example.com',
                     'urn': 'urn:mailto:bruger@example.com',
                     'validity': {
-                        'from': '1934-06-09T00:00:00+01:00',
+                        'from': '1934-06-09',
                         'to': None,
                     },
                 },
@@ -519,7 +519,7 @@ class Writing(util.LoRATestCase):
                     'obj': {
                         'data': {
                             'validity': {
-                                'to': '2010-01-01T00:00:00+01:00'
+                                'to': '2009-12-31'
                             }
                         },
                         'original': None,
@@ -533,7 +533,7 @@ class Writing(util.LoRATestCase):
                     "original": None,
                     "data": {
                         "validity": {
-                            'to': '2010-01-01T00:00:00+01:00',
+                            'to': '2009-12-31',
                         },
                     }
                 }],
@@ -563,13 +563,13 @@ class Writing(util.LoRATestCase):
                         'name': 'user@example.com',
                         'urn': 'urn:mailto:user@example.com',
                         'validity': {
-                            'from': '1934-06-09T00:00:00+01:00',
+                            'from': '1934-06-09',
                             'to': None,
                         },
                     },
                     "data": {
                         "validity": {
-                            'to': '2010-01-01T00:00:00+01:00',
+                            'to': '2009-12-31',
                         },
                     }
                 }],
@@ -593,14 +593,14 @@ class Writing(util.LoRATestCase):
                     'name': 'bruger@example.com',
                     'urn': 'urn:mailto:bruger@example.com',
                     'validity': {
-                        'from': '1934-06-09T00:00:00+01:00',
+                        'from': '1934-06-09',
                         'to': None,
                     },
                 },
                 "data": {
                     'value': 'user@example.com',
                     "validity": {
-                        'to': '2010-01-01T00:00:00+01:00',
+                        'to': '2009-12-31',
                     },
                 }
             }],
@@ -616,8 +616,8 @@ class Writing(util.LoRATestCase):
                     'name': 'user@example.com',
                     'urn': 'urn:mailto:user@example.com',
                     'validity': {
-                        'from': '1934-06-09T00:00:00+01:00',
-                        'to': '2010-01-01T00:00:00+01:00',
+                        'from': '1934-06-09',
+                        'to': '2009-12-31',
                     },
                 },
             ],
@@ -651,8 +651,8 @@ class Writing(util.LoRATestCase):
                     'name': 'user@example.com',
                     'urn': 'urn:mailto:user@example.com',
                     'validity': {
-                        'from': '1934-06-09T00:00:00+01:00',
-                        'to': '2010-01-01T00:00:00+01:00',
+                        'from': '1934-06-09',
+                        'to': '2009-12-31',
                     },
                 },
                 "data": {
@@ -687,7 +687,7 @@ class Writing(util.LoRATestCase):
                     'name': 'Pilestræde 43, 3., 1112 København K',
                     'uuid': '0a3f50a0-23c9-32b8-e044-0003ba298018',
                     'validity': {
-                        'from': '1934-06-09T00:00:00+01:00',
+                        'from': '1934-06-09',
                         'to': None,
                     },
                 },
@@ -738,7 +738,7 @@ class Writing(util.LoRATestCase):
                 "name": "Christiansborg Slotsplads 1, 1218 K\u00f8benhavn K",
                 "uuid": "bae093df-3b06-4f23-90a8-92eabedb3622",
                 "validity": {
-                    "from": "1932-05-12T00:00:00+01:00",
+                    "from": "1932-05-12",
                     "to": None
                 }
             },
@@ -748,7 +748,7 @@ class Writing(util.LoRATestCase):
                 "name": "goofy@example.com",
                 "urn": "urn:mailto:goofy@example.com",
                 "validity": {
-                    "from": "1932-05-12T00:00:00+01:00",
+                    "from": "1932-05-12",
                     "to": None
                 }
             },
@@ -758,7 +758,7 @@ class Writing(util.LoRATestCase):
                 "name": "goofy@example.com",
                 "urn": "urn:mailto:goofy@example.com",
                 "validity": {
-                    "from": "1932-05-12T00:00:00+01:00",
+                    "from": "1932-05-12",
                     "to": None
                 }
             }
@@ -855,7 +855,7 @@ class Writing(util.LoRATestCase):
             'name': 'bruger@example.com',
             'urn': 'urn:mailto:bruger@example.com',
             'validity': {
-                'from': '1934-06-09T00:00:00+01:00',
+                'from': '1934-06-09',
                 'to': None,
             },
         }
@@ -892,7 +892,7 @@ class Writing(util.LoRATestCase):
                     'name': 'hest@example.com',
                     'urn': 'urn:mailto:hest@example.com',
                     'validity': {
-                        'from': '1934-06-09T00:00:00+01:00',
+                        'from': '1934-06-09',
                         'to': None,
                     },
                 }
@@ -930,8 +930,8 @@ class Writing(util.LoRATestCase):
             "name": "Nordre Ringgade 1, 8000 Aarhus C",
             "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197",
             "validity": {
-                "from": "2016-01-01T00:00:00+01:00",
-                "to": "2019-01-01T00:00:00+01:00"
+                "from": "2016-01-01",
+                "to": "2018-12-31"
             }
         }
 
@@ -964,8 +964,8 @@ class Writing(util.LoRATestCase):
                 'name': '1234567890',
                 'urn': 'urn:magenta.dk:ean:1234567890',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
-                    'to': '2019-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
+                    'to': '2018-12-31',
                 },
             }],
         )
@@ -978,8 +978,8 @@ class Writing(util.LoRATestCase):
                 'name': '1234567890',
                 'urn': 'urn:magenta.dk:ean:1234567890',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
-                    'to': '2019-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
+                    'to': '2018-12-31',
                 },
             }],
         )
@@ -1039,7 +1039,7 @@ class Writing(util.LoRATestCase):
                 'name': '5798000420229',
                 'urn': 'urn:magenta.dk:ean:5798000420229',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
             },
             {
@@ -1054,7 +1054,7 @@ class Writing(util.LoRATestCase):
                 'name': '87150000',
                 'urn': 'urn:magenta.dk:telefon:+4587150000',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
             },
             {
@@ -1070,7 +1070,7 @@ class Writing(util.LoRATestCase):
                 'name': 'Nordre Ringgade 1, 8000 Aarhus C',
                 'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
             },
         ]
@@ -1148,7 +1148,7 @@ class Writing(util.LoRATestCase):
                         },
                         'type': 'address',
                         'validity': {
-                            'from': '2013-01-01T00:00:00+01:00',
+                            'from': '2013-01-01',
                             'to': None
                         }
                     },
@@ -1160,7 +1160,7 @@ class Writing(util.LoRATestCase):
                         "address_type": email_class,
                         # NB: no value
                         "validity": {
-                            "from": "2013-01-01T00:00:00+01:00",
+                            "from": "2013-01-01",
                             "to": None,
                         },
                     },
@@ -1184,7 +1184,7 @@ class Writing(util.LoRATestCase):
                         'address_type': None,
                         'type': 'address',
                         'validity': {
-                            'from': '2013-01-01T00:00:00+01:00',
+                            'from': '2013-01-01',
                             'to': None},
                         'value': 'hallo@exmaple.com'
                     },
@@ -1197,7 +1197,7 @@ class Writing(util.LoRATestCase):
                         "address_type": None,
                         "value": "hallo@exmaple.com",
                         "validity": {
-                            "from": "2013-01-01T00:00:00+01:00",
+                            "from": "2013-01-01",
                             "to": None,
                         },
                     },
@@ -1223,7 +1223,7 @@ class Writing(util.LoRATestCase):
                         },
                         'type': 'address',
                         'validity': {
-                            'from': '2013-01-01T00:00:00+01:00',
+                            'from': '2013-01-01',
                             'to': None},
                         'value': 'hallo@exmaple.com'
                     },
@@ -1236,7 +1236,7 @@ class Writing(util.LoRATestCase):
                         # NB: wrong key!
                         "value": "hallo@exmaple.com",
                         "validity": {
-                            "from": "2013-01-01T00:00:00+01:00",
+                            "from": "2013-01-01",
                             "to": None,
                         },
                     },
@@ -1264,7 +1264,7 @@ class Writing(util.LoRATestCase):
                         'type': 'address',
                         'uuid': 'hallo@exmaple.com',
                         'validity': {
-                            'from': '2013-01-01T00:00:00+01:00',
+                            'from': '2013-01-01',
                             'to': None
                         }
                     },
@@ -1277,7 +1277,7 @@ class Writing(util.LoRATestCase):
                         # NB: not a UUID!
                         "uuid": "hallo@exmaple.com",
                         "validity": {
-                            "from": "2013-01-01T00:00:00+01:00",
+                            "from": "2013-01-01",
                             "to": None,
                         },
                     },
@@ -1295,7 +1295,7 @@ class Writing(util.LoRATestCase):
                     "address_type": email_class,
                     "value": "hallo@exmaple.com",
                     "validity": {
-                        "from": "2013-01-01T00:00:00+01:00",
+                        "from": "2013-01-01",
                         "to": None,
                     },
                 },
@@ -1342,8 +1342,8 @@ class Writing(util.LoRATestCase):
                     },
                     "value": "11 22 33 44",
                     "validity": {
-                        "from": "2015-02-04T00:00:00+01",
-                        "to": "2017-10-22T00:00:00+02",
+                        "from": "2015-02-04",
+                        "to": "2017-10-21",
                     }
                 },
                 {
@@ -1358,8 +1358,8 @@ class Writing(util.LoRATestCase):
                 },
             ],
             "validity": {
-                "from": "2016-02-04T00:00:00+01",
-                "to": "2017-10-22T00:00:00+02",
+                "from": "2016-02-04",
+                "to": "2017-10-21",
             }
         }
 
@@ -1415,15 +1415,15 @@ class Writing(util.LoRATestCase):
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
                 'user_key': 'Fake Corp 00000000-0000-0000-0000-000000000000',
                 'uuid': unitid,
                 'validity': {
-                    'from': '2016-02-04T00:00:00+01:00',
-                    'to': '2017-10-22T00:00:00+02:00',
+                    'from': '2016-02-04',
+                    'to': '2017-10-21',
                 },
             },
         )
@@ -1461,8 +1461,8 @@ class Writing(util.LoRATestCase):
                     'href': 'tel:+4511223344',
                     'name': '11223344',
                     'validity': {
-                        'from': '2015-02-04T00:00:00+01:00',
-                        'to': '2017-10-22T00:00:00+02:00',
+                        'from': '2015-02-04',
+                        'to': '2017-10-21',
                     },
                     'urn': 'urn:magenta.dk:telefon:+4511223344',
                 },
@@ -1478,8 +1478,8 @@ class Writing(util.LoRATestCase):
                             '?mlon=10.18779751&mlat=56.17233057&zoom=16',
                     'name': 'Åbogade 15, 8200 Aarhus N',
                     'validity': {
-                        'from': '2016-02-04T00:00:00+01:00',
-                        'to': '2017-10-22T00:00:00+02:00',
+                        'from': '2016-02-04',
+                        'to': '2017-10-21',
                     },
                     'uuid': '44c532e1-f617-4174-b144-d37ce9fda2bd',
                 },
@@ -1514,8 +1514,8 @@ class Writing(util.LoRATestCase):
                 "uuid": "4e337d8e-1fd2-4449-8110-e0c8a22958ed",
             },
             "validity": {
-                "from": "2016-01-01T00:00:00+01:00",
-                "to": "2019-01-01T00:00:00+01:00",
+                "from": "2016-01-01",
+                "to": "2018-12-31",
             },
         }
 
@@ -1587,8 +1587,8 @@ class Writing(util.LoRATestCase):
                 'name': '87150000',
                 'urn': 'urn:magenta.dk:telefon:+4587150000',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
-                    'to': '2019-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
+                    'to': '2018-12-31',
                 },
             }],
         )
@@ -1645,7 +1645,7 @@ class Writing(util.LoRATestCase):
                 'href': None,
                 'name': '5798000420229',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
                 'urn': 'urn:magenta.dk:ean:5798000420229',
             },
@@ -1660,7 +1660,7 @@ class Writing(util.LoRATestCase):
                 'href': 'tel:+4587150000',
                 'name': '87150000',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
                 'urn': 'urn:magenta.dk:telefon:+4587150000',
             },
@@ -1676,7 +1676,7 @@ class Writing(util.LoRATestCase):
                 '?mlon=10.19938084&mlat=56.17102843&zoom=16',
                 'name': 'Nordre Ringgade 1, 8000 Aarhus C',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
                 'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
             },
@@ -1720,8 +1720,7 @@ class Writing(util.LoRATestCase):
                     },
                     'value': 'root@example.com',
                     "validity": {
-                        # Note: The timestamp isn't midnight!
-                        "from": "2017-01-01T12:00:00+01",
+                        "from": "2017-01-02",
                     },
                 },
             ],
@@ -1731,7 +1730,7 @@ class Writing(util.LoRATestCase):
             'objekttype': 'c78eb6f7-8a9e-40b3-ac80-36b9f371c3e0',
             'urn': 'urn:mailto:root@example.com',
             'virkning': {
-                'from': '2017-01-01 12:00:00+01',
+                'from': '2017-01-02 00:00:00+01',
                 'to': 'infinity',
                 'from_included': True,
                 'to_included': False,
@@ -1749,7 +1748,7 @@ class Writing(util.LoRATestCase):
             'href': 'mailto:root@example.com',
             'name': 'root@example.com',
             'validity': {
-                'from': '2017-01-01T12:00:00+01:00',
+                'from': '2017-01-02',
                 'to': None,
             },
             'urn': 'urn:mailto:root@example.com',
@@ -1789,7 +1788,7 @@ class Writing(util.LoRATestCase):
                 "href": "tel:+4587150000",
                 "name": "87150000",
                 "validity": {
-                    "from": "2016-01-01T00:00:00+01:00",
+                    "from": "2016-01-01",
                     "to": None
                 },
                 "urn": "urn:magenta.dk:telefon:+4587150000"
@@ -1806,7 +1805,7 @@ class Writing(util.LoRATestCase):
                 "?mlon=10.19938084&mlat=56.17102843&zoom=16",
                 "name": "Nordre Ringgade 1, 8000 Aarhus C",
                 "validity": {
-                    "from": "2016-01-01T00:00:00+01:00",
+                    "from": "2016-01-01",
                     "to": None
                 },
                 "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197"
@@ -1836,7 +1835,7 @@ class Writing(util.LoRATestCase):
             '/service/ou/{}/edit'.format(unitid),
             unitid, json=req)
 
-        addresses[1]['validity']['from'] = '2016-06-01T00:00:00+02:00'
+        addresses[1]['validity']['from'] = '2016-06-01'
         addresses[1].update(
             name='Nordre Ringgade 2, 8000 Aarhus C',
             uuid='d901ff7e-8ad9-4581-84c7-5759aaa82f7b',
@@ -1868,7 +1867,7 @@ class Writing(util.LoRATestCase):
                 "href": "tel:+4587150000",
                 "name": "87150000",
                 "validity": {
-                    "from": "2016-01-01T00:00:00+01:00",
+                    "from": "2016-01-01",
                     "to": None
                 },
                 "urn": "urn:magenta.dk:telefon:+4587150000"
@@ -1885,7 +1884,7 @@ class Writing(util.LoRATestCase):
                 "?mlon=10.19938084&mlat=56.17102843&zoom=16",
                 "name": "Nordre Ringgade 1, 8000 Aarhus C",
                 "validity": {
-                    "from": "2016-01-01T00:00:00+01:00",
+                    "from": "2016-01-01",
                     "to": None
                 },
                 "uuid": "b1f1817d-5f02-4331-b8b3-97330a5d3197"
@@ -1930,7 +1929,7 @@ class Writing(util.LoRATestCase):
             'href': 'https://www.openstreetmap.org/'
             '?mlon=10.20019416&mlat=56.17063452&zoom=16',
             'name': 'Nordre Ringgade 2, 8000 Aarhus C',
-            'validity': {'from': '2016-06-01T00:00:00+02:00', 'to': None},
+            'validity': {'from': '2016-06-01', 'to': None},
             'uuid': 'd901ff7e-8ad9-4581-84c7-5759aaa82f7b',
         })
 
@@ -1976,7 +1975,7 @@ class Reading(util.LoRATestCase):
                         'Christiansborg Slotsplads 1, 1218 København K',
                         'uuid': 'bae093df-3b06-4f23-90a8-92eabedb3622',
                         'validity': {
-                            'from': '1932-05-12T00:00:00+01:00',
+                            'from': '1932-05-12',
                             'to': None,
                         },
                     },
@@ -1992,7 +1991,7 @@ class Reading(util.LoRATestCase):
                         'name': 'goofy@example.com',
                         'urn': 'urn:mailto:goofy@example.com',
                         'validity': {
-                            'from': '1932-05-12T00:00:00+01:00',
+                            'from': '1932-05-12',
                             'to': None,
                         },
                     },
@@ -2008,7 +2007,7 @@ class Reading(util.LoRATestCase):
                         'name': 'goofy@example.com',
                         'urn': 'urn:mailto:goofy@example.com',
                         'validity': {
-                            'from': '1932-05-12T00:00:00+01:00',
+                            'from': '1932-05-12',
                             'to': None,
                         },
                     },
@@ -2032,7 +2031,7 @@ class Reading(util.LoRATestCase):
                         'name': 'bruger@example.com',
                         'urn': 'urn:mailto:bruger@example.com',
                         'validity': {
-                            'from': '1934-06-09T00:00:00+01:00',
+                            'from': '1934-06-09',
                             'to': None,
                         },
                     },
@@ -2056,7 +2055,7 @@ class Reading(util.LoRATestCase):
                         'name': '5798000420229',
                         'urn': 'urn:magenta.dk:ean:5798000420229',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -2072,7 +2071,7 @@ class Reading(util.LoRATestCase):
                         'name': '87150000',
                         'urn': 'urn:magenta.dk:telefon:+4587150000',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -2089,7 +2088,7 @@ class Reading(util.LoRATestCase):
                         'name': 'Nordre Ringgade 1, 8000 Aarhus C',
                         'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         }
                     },
@@ -2113,7 +2112,7 @@ class Reading(util.LoRATestCase):
                         'name': '87150000',
                         'urn': 'urn:magenta.dk:telefon:+4587150000',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -2130,7 +2129,7 @@ class Reading(util.LoRATestCase):
                         'name': 'Nordre Ringgade 1, 8000 Aarhus C',
                         'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -2154,7 +2153,7 @@ class Reading(util.LoRATestCase):
                         'name': '87150000',
                         'urn': 'urn:magenta.dk:telefon:+4587150000',
                         'validity': {
-                            'from': '2017-01-01T00:00:00+01:00',
+                            'from': '2017-01-01',
                             'to': None,
                         },
                     },
@@ -2171,7 +2170,7 @@ class Reading(util.LoRATestCase):
                         'name': 'Nordre Ringgade 1, 8000 Aarhus C',
                         'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
                         'validity': {
-                            'from': '2017-01-01T00:00:00+01:00',
+                            'from': '2017-01-01',
                             'to': None,
                         },
                     },
@@ -2195,7 +2194,7 @@ class Reading(util.LoRATestCase):
                         'name': '87150000',
                         'urn': 'urn:magenta.dk:telefon:+4587150000',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -2212,7 +2211,7 @@ class Reading(util.LoRATestCase):
                         'name': 'Nordre Ringgade 1, 8000 Aarhus C',
                         'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -2237,8 +2236,8 @@ class Reading(util.LoRATestCase):
                         'name': 'Nordre Ringgade 1, 8000 Aarhus C',
                         'uuid': 'b1f1817d-5f02-4331-b8b3-97330a5d3197',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                 ],
@@ -2362,8 +2361,8 @@ class Reading(util.LoRATestCase):
                             'uuid':
                             'b1f1817d-5f02-4331-b8b3-97330a5d3197',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
-                                'to': '2019-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
+                                'to': '2018-12-31',
                             },
                         },
                     ],

--- a/backend/tests/test_integration_association.py
+++ b/backend/tests/test_integration_association.py
@@ -46,8 +46,8 @@ class Tests(util.LoRATestCase):
                     'value': '33369696',
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -198,7 +198,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': unitid,
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -208,8 +208,8 @@ class Tests(util.LoRATestCase):
             },
             'uuid': associationid,
             'validity': {
-                'from': '2017-12-01T00:00:00+01:00',
-                'to': '2017-12-02T00:00:00+01:00',
+                'from': '2017-12-01',
+                'to': '2017-12-01',
             },
         }]
 
@@ -254,8 +254,8 @@ class Tests(util.LoRATestCase):
                     'value': '33369696',
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -300,8 +300,8 @@ class Tests(util.LoRATestCase):
                     'uuid': '0a3f50a0-23c9-32b8-e044-0003ba298018',
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -442,7 +442,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': unitid,
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -452,8 +452,8 @@ class Tests(util.LoRATestCase):
             },
             'uuid': associationid,
             'validity': {
-                'from': '2017-12-01T00:00:00+01:00',
-                'to': '2017-12-02T00:00:00+01:00',
+                'from': '2017-12-01',
+                'to': '2017-12-01',
             },
         }]
 
@@ -498,7 +498,7 @@ class Tests(util.LoRATestCase):
                     'uuid': '0a3f50a0-23c9-32b8-e044-0003ba298018',
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
+                    "from": "2017-12-01",
                 },
             }
         ]
@@ -650,7 +650,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -660,7 +660,7 @@ class Tests(util.LoRATestCase):
             },
             'uuid': associationid,
             'validity': {
-                'from': '2017-12-01T00:00:00+01:00',
+                'from': '2017-12-01',
                 'to': None,
             },
         }]
@@ -708,7 +708,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -886,7 +886,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -896,8 +896,8 @@ class Tests(util.LoRATestCase):
             },
             'uuid': 'c2153d5d-4a2b-492d-a18c-c498f7bb6221',
             'validity': {
-                'from': '2017-01-01T00:00:00+01:00',
-                'to': '2018-04-01T00:00:00+02:00',
+                'from': '2017-01-01',
+                'to': '2018-03-31',
             },
         }]
 
@@ -934,7 +934,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -944,7 +944,7 @@ class Tests(util.LoRATestCase):
             },
             'uuid': association_uuid,
             'validity': {
-                'from': '2018-04-01T00:00:00+02:00',
+                'from': '2018-04-01',
                 'to': None,
             },
         }]
@@ -992,8 +992,8 @@ class Tests(util.LoRATestCase):
                     'value': '33369696',
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -1018,8 +1018,8 @@ class Tests(util.LoRATestCase):
             "uuid": association_uuid,
             "data": {
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
                 "org_unit": {
                     "uuid": unitid
@@ -1054,7 +1054,7 @@ class Tests(util.LoRATestCase):
             "uuid": association_uuid,
             "original": {
                 "validity": {
-                    "from": "2017-01-01 00:00:00+01",
+                    "from": "2017-01-01",
                     "to": None
                 },
                 "org_unit": {'uuid': unitid},
@@ -1071,7 +1071,7 @@ class Tests(util.LoRATestCase):
                 "association_type": {
                     'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"},
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -1236,7 +1236,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -1246,7 +1246,7 @@ class Tests(util.LoRATestCase):
             },
             'uuid': association_uuid,
             'validity': {
-                'from': '2018-04-01T00:00:00+02:00',
+                'from': '2018-04-01',
                 'to': None,
             },
         }]
@@ -1277,8 +1277,8 @@ class Tests(util.LoRATestCase):
             "data": {
                 "org_unit": {'uuid': unitid},
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
-                    "to": "2019-04-01T00:00:00+02",
+                    "from": "2018-04-01",
+                    "to": "2019-03-31",
                 },
             },
         }]
@@ -1454,7 +1454,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -1464,8 +1464,8 @@ class Tests(util.LoRATestCase):
             },
             'uuid': association_uuid,
             'validity': {
-                'from': '2017-01-01T00:00:00+01:00',
-                'to': '2018-04-01T00:00:00+02:00',
+                'from': '2017-01-01',
+                'to': '2018-03-31',
             },
         }]
 
@@ -1482,7 +1482,7 @@ class Tests(util.LoRATestCase):
 
         # second, check post-move
         expected[0].update(validity={
-            'from': '2019-04-01T00:00:00+02:00',
+            'from': '2019-04-01',
             'to': None,
         })
 
@@ -1505,13 +1505,13 @@ class Tests(util.LoRATestCase):
                 'user_key': 'samf',
                 'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
                 'validity': {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None,
                 },
             },
             validity={
-                'from': '2018-04-01T00:00:00+02:00',
-                'to': '2019-04-01T00:00:00+02:00',
+                'from': '2018-04-01',
+                'to': '2019-03-31',
             },
         )
 
@@ -1539,7 +1539,7 @@ class Tests(util.LoRATestCase):
             "data": {
                 "org_unit": {'uuid': unitid},
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -1697,7 +1697,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -1707,8 +1707,8 @@ class Tests(util.LoRATestCase):
             },
             'uuid': association_uuid,
             'validity': {
-                'from': '2017-01-01T00:00:00+01:00',
-                'to': '2018-04-01T00:00:00+02:00',
+                'from': '2017-01-01',
+                'to': '2018-03-31',
             },
         }]
 
@@ -1723,12 +1723,12 @@ class Tests(util.LoRATestCase):
                 'user_key': 'samf',
                 'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
                 'validity': {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None,
                 },
             },
             validity={
-                'from': '2018-04-01T00:00:00+02:00',
+                'from': '2018-04-01',
                 'to': None,
             },
         )
@@ -1749,7 +1749,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-12-01T00:00:00+01"
+                "from": "2017-11-30"
             }
         }
 
@@ -1904,7 +1904,7 @@ class AddressTests(util.LoRATestCase):
                     },
                 },
                 "validity": {
-                    "from": "2017-01-01T00:00:00+01",
+                    "from": "2017-01-01",
                 },
             },
         }]
@@ -1945,7 +1945,7 @@ class AddressTests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -1955,7 +1955,7 @@ class AddressTests(util.LoRATestCase):
             },
             'uuid': association_uuid,
             'validity': {
-                'from': '2017-01-01T00:00:00+01:00',
+                'from': '2017-01-01',
                 'to': None,
             },
         }]
@@ -1967,8 +1967,8 @@ class AddressTests(util.LoRATestCase):
 
         expected[0].update(
             validity={
-                'from': '2017-01-01T00:00:00+01:00',
-                'to': '2018-04-01T00:00:00+02:00',
+                'from': '2017-01-01',
+                'to': '2018-03-31',
             },
         )
 
@@ -1987,7 +1987,7 @@ class AddressTests(util.LoRATestCase):
                     "uuid": "44c532e1-f617-4174-b144-d37ce9fda2bd",
                 },
                 "validity": {
-                    "from": "2017-06-01T00:00:00+02",
+                    "from": "2017-06-01",
                 },
             },
         }]
@@ -1996,7 +1996,7 @@ class AddressTests(util.LoRATestCase):
             '/service/e/{}/edit'.format(userid),
             userid, json=req)
 
-        expected[0]['validity']['to'] = "2017-06-01T00:00:00+02:00"
+        expected[0]['validity']['to'] = "2017-05-31"
 
         self.assertRequestResponse(
             '/service/e/{}/details/association'.format(userid),
@@ -2148,7 +2148,7 @@ class AddressTests(util.LoRATestCase):
                 'uuid': '44c532e1-f617-4174-b144-d37ce9fda2bd',
             },
             validity={
-                'from': '2017-06-01T00:00:00+02:00',
+                'from': '2017-06-01',
                 'to': None,
             },
         )

--- a/backend/tests/test_integration_association.py
+++ b/backend/tests/test_integration_association.py
@@ -1749,7 +1749,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-11-30"
+                "to": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_engagement.py
+++ b/backend/tests/test_integration_engagement.py
@@ -33,8 +33,8 @@ class Tests(util.LoRATestCase):
                 "engagement_type": {
                     'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"},
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 }
             }
         ]
@@ -165,7 +165,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
+                    "from": "2017-12-01",
                 }
             }
         ]
@@ -293,8 +293,8 @@ class Tests(util.LoRATestCase):
                 "engagement_type": {
                     'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"},
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 }
             }
         ]
@@ -422,7 +422,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 }
             },
         }]
@@ -571,7 +571,7 @@ class Tests(util.LoRATestCase):
             "uuid": engagement_uuid,
             "original": {
                 "validity": {
-                    "from": "2017-01-01 00:00:00+01",
+                    "from": "2017-01-01",
                     "to": None,
                 },
                 "org_unit": {'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"},
@@ -586,7 +586,7 @@ class Tests(util.LoRATestCase):
                 "engagement_type": {
                     'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"},
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 }
             },
         }]
@@ -736,8 +736,8 @@ class Tests(util.LoRATestCase):
             "data": {
                 "org_unit": {'uuid': "b688513d-11f7-4efc-b679-ab082a2055d0"},
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
-                    "to": "2019-04-01T00:00:00+02",
+                    "from": "2018-04-01",
+                    "to": "2019-03-31",
                 },
             },
         }]
@@ -890,7 +890,7 @@ class Tests(util.LoRATestCase):
             "data": {
                 "org_unit": {'uuid': "b688513d-11f7-4efc-b679-ab082a2055d0"},
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 }
             },
         }]
@@ -1021,7 +1021,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-12-01T00:00:00+01"
+                "from": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_engagement.py
+++ b/backend/tests/test_integration_engagement.py
@@ -1021,7 +1021,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-11-30"
+                "to": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_history.py
+++ b/backend/tests/test_integration_history.py
@@ -29,7 +29,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "uuid": 'd000591f-8705-4324-897a-075e3623f37b',
                     "data": {
                         "validity": {
-                            "from": "2018-04-01T00:00:00+02",
+                            "from": "2018-04-01",
                         }
                     },
                 },
@@ -38,7 +38,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "uuid": 'c2153d5d-4a2b-492d-a18c-c498f7bb6221',
                     "data": {
                         "validity": {
-                            "from": "2018-04-01T00:00:00+02",
+                            "from": "2018-04-01",
                         }
                     },
                 },
@@ -47,7 +47,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "uuid": '1b20d0b9-96a0-42a6-b196-293bb86e62e8',
                     "data": {
                         "validity": {
-                            "from": "2018-04-01T00:00:00+02",
+                            "from": "2018-04-01",
                         }
                     },
                 },
@@ -56,7 +56,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "uuid": 'b807628c-030c-4f5f-a438-de41c1f26ba5',
                     "data": {
                         "validity": {
-                            "from": "2018-04-01T00:00:00+02",
+                            "from": "2018-04-01",
                         }
                     },
                 },
@@ -65,7 +65,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "uuid": '05609702-977f-4869-9fb4-50ad74c6999a',
                     "data": {
                         "validity": {
-                            "from": "2018-04-01T00:00:00+02",
+                            "from": "2018-04-01",
                         }
                     },
                 },
@@ -84,8 +84,8 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "engagement_type": {
                         'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"},
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
-                        "to": "2017-12-02T00:00:00+01",
+                        "from": "2017-12-01",
+                        "to": "2017-12-01",
                     }
                 },
                 {
@@ -98,8 +98,8 @@ class EmployeeHistoryTest(util.LoRATestCase):
                         'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"
                     },
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
-                        "to": "2017-12-02T00:00:00+01",
+                        "from": "2017-12-01",
+                        "to": "2017-12-01",
                     },
                 },
                 {
@@ -109,8 +109,8 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "role_type": {
                         'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"},
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
-                        "to": "2017-12-02T00:00:00+01",
+                        "from": "2017-12-01",
+                        "to": "2017-12-01",
                     },
                 },
                 {
@@ -118,8 +118,8 @@ class EmployeeHistoryTest(util.LoRATestCase):
                     "leave_type": {
                         'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"},
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
-                        "to": "2017-12-02T00:00:00+01",
+                        "from": "2017-12-01",
+                        "to": "2017-12-01",
                     },
                 },
                 {
@@ -135,8 +135,8 @@ class EmployeeHistoryTest(util.LoRATestCase):
                         "uuid": "1edc778c-bf9b-4e7e-b287-9adecd6ee293"
                     },
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
-                        "to": "2017-12-02T00:00:00+01",
+                        "from": "2017-12-01",
+                        "to": "2017-12-01",
                     },
                 },
             ])
@@ -146,7 +146,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
             userid,
             json={
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01"
+                    "from": "2017-12-01"
                 }
             })
 
@@ -246,8 +246,8 @@ class OrgUnitHistoryTest(util.LoRATestCase):
                     'uuid': "3ef81e52-0deb-487d-9d0e-a69bbe0277d8"
                 },
                 "validity": {
-                    "from": "2016-02-04T00:00:00+01",
-                    "to": "2017-10-22T00:00:00+02",
+                    "from": "2016-02-04",
+                    "to": "2017-10-21",
                 }
             }
         )
@@ -261,7 +261,7 @@ class OrgUnitHistoryTest(util.LoRATestCase):
                 "data": {
                     "name": "History test II",
                     "validity": {
-                        "from": "2016-01-05T00:00:00+00:00",
+                        "from": "2016-01-05",
                     }
                 }
             }
@@ -274,7 +274,7 @@ class OrgUnitHistoryTest(util.LoRATestCase):
                 "data": {
                     "name": "History test III",
                     "validity": {
-                        "from": "2016-01-12T00:00:00+00:00",
+                        "from": "2016-01-12",
                     }
                 }
             }
@@ -285,7 +285,7 @@ class OrgUnitHistoryTest(util.LoRATestCase):
             unitid,
             json={
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01"
+                    "from": "2017-12-01"
                 }
             })
 

--- a/backend/tests/test_integration_history.py
+++ b/backend/tests/test_integration_history.py
@@ -146,7 +146,7 @@ class EmployeeHistoryTest(util.LoRATestCase):
             userid,
             json={
                 "validity": {
-                    "from": "2017-12-01"
+                    "to": "2017-12-01"
                 }
             })
 
@@ -285,7 +285,7 @@ class OrgUnitHistoryTest(util.LoRATestCase):
             unitid,
             json={
                 "validity": {
-                    "from": "2017-12-01"
+                    "to": "2017-12-01"
                 }
             })
 

--- a/backend/tests/test_integration_importing.py
+++ b/backend/tests/test_integration_importing.py
@@ -577,7 +577,7 @@ class IntegrationTests(util.LoRATestCase):
                 'user_key': 'BALLERUP',
                 'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                 'validity': {
-                    'from': '1964-05-24T00:00:00+01:00',
+                    'from': '1964-05-24',
                     'to': None,
                 },
             }],
@@ -589,17 +589,17 @@ class IntegrationTests(util.LoRATestCase):
               'name': 'Ballerup Bibliotek',
               'user_key': 'BIBLIOTEK',
               'uuid': '921e44d3-2ec0-4c16-9935-2ec7976566dc',
-              'validity': {'from': '1993-01-01T00:00:00+01:00', 'to': None}},
+              'validity': {'from': '1993-01-01', 'to': None}},
              {'child_count': 0,
               'name': 'Ballerup Familiehus',
               'user_key': 'FAMILIEHUS',
               'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9',
-              'validity': {'from': '2006-01-01T00:00:00+01:00', 'to': None}},
+              'validity': {'from': '2006-01-01', 'to': None}},
              {'child_count': 0,
               'name': 'Ballerup Idrætspark',
               'user_key': 'IDRÆTSPARK',
               'uuid': 'ef04b6ba-8ba7-4a25-95e3-774f38e5d9bc',
-              'validity': {'from': '1993-01-01T00:00:00+01:00', 'to': None}}],
+              'validity': {'from': '1993-01-01', 'to': None}}],
         )
 
         for childid in (
@@ -632,7 +632,7 @@ class IntegrationTests(util.LoRATestCase):
                 },
                 'parent': None,
                 'validity': {
-                    'from': '1964-05-24T00:00:00+01:00',
+                    'from': '1964-05-24',
                     'to': None,
                 },
             },
@@ -657,13 +657,13 @@ class IntegrationTests(util.LoRATestCase):
                     'user_key': 'BALLERUP',
                     'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                     'validity': {
-                        'from': '1964-05-24T00:00:00+01:00',
+                        'from': '1964-05-24',
                         'to': None,
                     },
                 },
                 'user_key': 'FAMILIEHUS',
                 'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9',
-                'validity': {'from': '2006-01-01T00:00:00+01:00', 'to': None},
+                'validity': {'from': '2006-01-01', 'to': None},
             },
         )
 
@@ -673,22 +673,22 @@ class IntegrationTests(util.LoRATestCase):
                 {'name': 'Ballerup Bibliotek',
                  'user_key': 'BIBLIOTEK',
                  'uuid': '921e44d3-2ec0-4c16-9935-2ec7976566dc',
-                 'validity': {'from': '1993-01-01T00:00:00+01:00',
+                 'validity': {'from': '1993-01-01',
                               'to': None}},
                 {'name': 'Ballerup Kommune',
                  'user_key': 'BALLERUP',
                  'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
-                 'validity': {'from': '1964-05-24T00:00:00+01:00',
+                 'validity': {'from': '1964-05-24',
                               'to': None}},
                 {'name': 'Ballerup Familiehus',
                  'user_key': 'FAMILIEHUS',
                  'uuid': 'c12393e9-ee1d-4b91-a6a9-a17508c055c9',
-                 'validity': {'from': '2006-01-01T00:00:00+01:00',
+                 'validity': {'from': '2006-01-01',
                               'to': None}},
                 {'name': 'Ballerup Idrætspark',
                  'user_key': 'IDRÆTSPARK',
                  'uuid': 'ef04b6ba-8ba7-4a25-95e3-774f38e5d9bc',
-                 'validity': {'from': '1993-01-01T00:00:00+01:00',
+                 'validity': {'from': '1993-01-01',
                               'to': None}}],
              'offset': 0,
              'total': 4},
@@ -831,7 +831,7 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             }
                         },
@@ -848,7 +848,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': 'dd30c279-8bba-43a9-b4b7-6ac96e722f86',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -871,7 +871,7 @@ class IntegrationTests(util.LoRATestCase):
                         'user_key': 'BALLERUP',
                         'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                         'validity': {
-                            'from': '1964-05-24T00:00:00+01:00',
+                            'from': '1964-05-24',
                             'to': None,
                         },
                     },
@@ -885,7 +885,7 @@ class IntegrationTests(util.LoRATestCase):
                         'uuid': '351fdf06-102a-4159-a5b4-69922b0ccde9'},
                     'uuid': '7eadc1d9-19f5-46c7-a6db-f661c3a8fbb9',
                     "validity": {
-                        'from': '2018-01-01T00:00:00+01:00',
+                        'from': '2018-01-01',
                         'to': None
                     },
                 }],
@@ -909,7 +909,7 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
@@ -926,7 +926,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': '7eadc1d9-19f5-46c7-a6db-f661c3a8fbb9',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -943,7 +943,7 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
@@ -960,7 +960,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': 'dd30c279-8bba-43a9-b4b7-6ac96e722f86',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -992,7 +992,7 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
@@ -1009,7 +1009,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': 'b4cd77e4-2ba0-47c7-93e9-22f7446abb57',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1034,7 +1034,7 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
@@ -1051,7 +1051,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': 'b4cd77e4-2ba0-47c7-93e9-22f7446abb57',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1070,7 +1070,7 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
@@ -1087,7 +1087,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': '3b204d9b-a0ba-48ad-9c20-778a49b6d3a9',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1104,7 +1104,7 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
@@ -1121,7 +1121,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': '3b204d9b-a0ba-48ad-9c20-778a49b6d3a9',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1148,7 +1148,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'uuid': 'd82de46c-e266-4810-9e8d-e99a0c9c18d5',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1199,13 +1199,13 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
                         'uuid': '8fb49f61-db3f-4f61-92c3-8a1dddd8051f',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1248,13 +1248,13 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
                         'uuid': '8fb49f61-db3f-4f61-92c3-8a1dddd8051f',
                         "validity": {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1278,7 +1278,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': '11221122',
                         'urn': 'urn:magenta.dk:telefon:+4511221122',
                         'validity': {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1295,7 +1295,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': 'Pilestræde 43, 3., 1112 København K',
                         'uuid': '0a3f50a0-23c9-32b8-e044-0003ba298018',
                         'validity': {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1311,7 +1311,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': 'sanne@example.com',
                         'urn': 'urn:mailto:sanne@example.com',
                         'validity': {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1335,7 +1335,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': '11223344',
                         'urn': 'urn:magenta.dk:telefon:+4511223344',
                         'validity': {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1351,7 +1351,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': 'sune@example.com',
                         'urn': 'urn:mailto:sune@example.com',
                         'validity': {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1368,7 +1368,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': 'Åbogade 15, 8200 Aarhus N',
                         'uuid': '44c532e1-f617-4174-b144-d37ce9fda2bd',
                         'validity': {
-                            'from': '2018-01-01T00:00:00+01:00',
+                            'from': '2018-01-01',
                             'to': None,
                         },
                     },
@@ -1392,7 +1392,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': '44772000',
                         'urn': 'urn:magenta.dk:telefon:+4544772000',
                         'validity': {
-                            'from': '1964-05-24T00:00:00+01:00',
+                            'from': '1964-05-24',
                             'to': None,
                         },
                     },
@@ -1409,7 +1409,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': 'Hold-An Vej 7, 2750 Ballerup',
                         'uuid': 'bd7e5317-4a9e-437b-8923-11156406b117',
                         'validity': {
-                            'from': '1964-05-24T00:00:00+01:00',
+                            'from': '1964-05-24',
                             'to': None,
                         },
                     },
@@ -1425,7 +1425,7 @@ class IntegrationTests(util.LoRATestCase):
                         'name': 'borger@balk.dk',
                         'urn': 'urn:mailto:borger@balk.dk',
                         'validity': {
-                            'from': '1964-05-24T00:00:00+01:00',
+                            'from': '1964-05-24',
                             'to': None,
                         },
                     },
@@ -1446,7 +1446,7 @@ class IntegrationTests(util.LoRATestCase):
                   'name': '44773333',
                   'urn': 'urn:magenta.dk:telefon:+4544773333',
                   'validity': {
-                      'from': '1993-01-01T00:00:00+01:00',
+                      'from': '1993-01-01',
                       'to': None}},
                  {'address_type': {
                      'example': '<UUID>',
@@ -1459,7 +1459,7 @@ class IntegrationTests(util.LoRATestCase):
                   'name': 'Banegårdspladsen 1, 2750 Ballerup',
                   'uuid': '99b29a62-01fd-40be-b5fe-8bfc4be35e83',
                   'validity': {
-                      'from': '1993-01-01T00:00:00+01:00',
+                      'from': '1993-01-01',
                       'to': None}},
                  {'address_type': {
                      'example': 'hpe@korsbaek.dk',
@@ -1471,7 +1471,7 @@ class IntegrationTests(util.LoRATestCase):
                   'name': 'ballerup-bibliotek@balk.dk',
                   'urn': 'urn:mailto:ballerup-bibliotek@balk.dk',
                   'validity': {
-                      'from': '1993-01-01T00:00:00+01:00',
+                      'from': '1993-01-01',
                       'to': None}}],
             )
 
@@ -1490,7 +1490,7 @@ class IntegrationTests(util.LoRATestCase):
                   'name': 'Torvevej 21, 2740 Skovlunde',
                   'uuid': '45b40fc3-bb75-412c-b122-d9df7b0ade94',
                   'validity': {
-                      'from': '2006-01-01T00:00:00+01:00',
+                      'from': '2006-01-01',
                       'to': None}}],
             )
 
@@ -1509,7 +1509,7 @@ class IntegrationTests(util.LoRATestCase):
                   'name': 'Ballerup Idrætsby 38, 2750 Ballerup',
                   'uuid': '9ab45e95-a42a-47c0-b284-e5d2377fc429',
                   'validity': {
-                      'from': '1993-01-01T00:00:00+01:00',
+                      'from': '1993-01-01',
                       'to': None}},
                  {'address_type': {
                      'example': 'hpe@korsbaek.dk',
@@ -1521,7 +1521,7 @@ class IntegrationTests(util.LoRATestCase):
                   'name': 'tbri@balk.dk',
                   'urn': 'urn:mailto:tbri@balk.dk',
                   'validity': {
-                      'from': '1993-01-01T00:00:00+01:00',
+                      'from': '1993-01-01',
                       'to': None}}],
             )
 
@@ -1562,7 +1562,7 @@ class IntegrationTests(util.LoRATestCase):
                         },
                         'parent': None,
                         'validity': {
-                            'from': '1964-05-24T00:00:00+01:00',
+                            'from': '1964-05-24',
                             'to': None,
                         },
                     },
@@ -1595,12 +1595,12 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
                         'validity': {
-                            'from': '1993-01-01T00:00:00+01:00',
+                            'from': '1993-01-01',
                             'to': None,
                         },
                     },
@@ -1633,12 +1633,12 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
                         'validity': {
-                            'from': '2006-01-01T00:00:00+01:00',
+                            'from': '2006-01-01',
                             'to': None,
                         },
                     },
@@ -1671,12 +1671,12 @@ class IntegrationTests(util.LoRATestCase):
                             'user_key': 'BALLERUP',
                             'uuid': '9f42976b-93be-4e0b-9a25-0dcb8af2f6b4',
                             'validity': {
-                                'from': '1964-05-24T00:00:00+01:00',
+                                'from': '1964-05-24',
                                 'to': None,
                             },
                         },
                         'validity': {
-                            'from': '1993-01-01T00:00:00+01:00',
+                            'from': '1993-01-01',
                             'to': None,
                         },
                     },

--- a/backend/tests/test_integration_itsystem.py
+++ b/backend/tests/test_integration_itsystem.py
@@ -47,7 +47,7 @@ class Writing(util.LoRATestCase):
                     'itsystem': None,
                     'type': 'it',
                     'validity': {
-                        'from': '2017-12-01T00:00:00+01', 'to': None
+                        'from': '2017-12-01', 'to': None
                     }
                 },
             },
@@ -56,7 +56,7 @@ class Writing(util.LoRATestCase):
                     "type": "it",
                     "itsystem": None,
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
+                        "from": "2017-12-01",
                         "to": None,
                     },
                 },
@@ -79,7 +79,7 @@ class Writing(util.LoRATestCase):
                         'uuid': '00000000-0000-0000-0000-000000000000',
                     },
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
+                        "from": "2017-12-01",
                         "to": None,
                     },
                 },
@@ -103,7 +103,7 @@ class Writing(util.LoRATestCase):
                     'itsystem': None,
                     'type': 'it',
                     'validity': {
-                        'from': '2017-12-01T00:00:00+01',
+                        'from': '2017-12-01',
                         'to': None
                     }
                 },
@@ -113,7 +113,7 @@ class Writing(util.LoRATestCase):
                     "type": "it",
                     "itsystem": None,
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
+                        "from": "2017-12-01",
                         "to": None,
                     },
                 },
@@ -191,7 +191,7 @@ class Writing(util.LoRATestCase):
                         'uuid': '42',
                     },
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
+                        "from": "2017-12-01",
                         "to": None,
                     },
                 },
@@ -219,13 +219,13 @@ class Writing(util.LoRATestCase):
                         # WRONG:
                         'uuid': '00000000-0000-0000-0000-000000000000',
                         "validity": {
-                            'from': '1932-05-12T00:00:00+01:00',
+                            'from': '1932-05-12',
                             'to': None,
                         },
                     },
                     "data": {
                         "validity": {
-                            "to": '2020-01-01T00:00:00+01:00',
+                            "to": '2019-12-31',
                         },
                     },
                 },
@@ -253,13 +253,13 @@ class Writing(util.LoRATestCase):
                         'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                         "validity": {
                             # WRONG:
-                            'from': '2010-02-14T00:00:00+01:00',
+                            'from': '2010-02-14',
                             'to': None,
                         },
                     },
                     "data": {
                         "validity": {
-                            "from": '2020-01-01T00:00:00+01:00',
+                            "from": '2020-01-01',
                         },
                     },
                 },
@@ -286,14 +286,14 @@ class Writing(util.LoRATestCase):
                         'user_key': 'AD',
                         'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                         "validity": {
-                            'from': '2001-02-14T00:00:00+01:00',
+                            'from': '2001-02-14',
                             # WRONG:
-                            'to': '3001-02-14T00:00:00+01:00',
+                            'to': '3001-02-13',
                         },
                     },
                     "data": {
                         "validity": {
-                            "to": '2020-01-01T00:00:00+01:00',
+                            "to": '2019-12-31',
                         },
                     },
                 },
@@ -323,7 +323,7 @@ class Writing(util.LoRATestCase):
                         'user_key': 'AD',
                         'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                         "validity": {
-                            'from': '1932-05-12T00:00:00+01:00',
+                            'from': '1932-05-12',
                             'to': None,
                         },
                     },
@@ -436,7 +436,7 @@ class Writing(util.LoRATestCase):
                         'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     },
                     "validity": {
-                        "from": "2017-12-01T00:00:00+01",
+                        "from": "2017-12-01",
                         "to": None,
                     },
                 },
@@ -487,7 +487,7 @@ class Writing(util.LoRATestCase):
                         'user_key': 'AD',
                         'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                         "validity": {
-                            'from': '2017-12-01T00:00:00+01:00',
+                            'from': '2017-12-01',
                             'to': None,
                         },
                     },
@@ -504,8 +504,8 @@ class Writing(util.LoRATestCase):
                         'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
                     },
                     "validity": {
-                        "from": "2016-01-01T00:00:00+01",
-                        "to": "2020-01-01T00:00:00+01",
+                        "from": "2016-01-01",
+                        "to": "2019-12-31",
                     },
                 },
             ],
@@ -585,7 +585,7 @@ class Writing(util.LoRATestCase):
                         'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     },
                     "validity": {
-                        "from": "2016-01-01T00:00:00+01",
+                        "from": "2016-01-01",
                         "to": None,
                     },
                 },
@@ -634,7 +634,7 @@ class Writing(util.LoRATestCase):
                     'user_key': 'AD',
                     'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -690,7 +690,7 @@ class Writing(util.LoRATestCase):
               'user_key': 'AD',
               'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
               "validity": {
-                  'from': '1932-05-12T00:00:00+01:00',
+                  'from': '1932-05-12',
                   'to': None},
               },
              {'name': 'Lokal Rammearkitektur',
@@ -699,8 +699,8 @@ class Writing(util.LoRATestCase):
               'user_key': 'LoRa',
               'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
               "validity": {
-                  'from': '2016-01-01T00:00:00+01:00',
-                  'to': '2018-01-01T00:00:00+01:00'
+                  'from': '2016-01-01',
+                  'to': '2017-12-31'
               },
               }],
         )
@@ -717,13 +717,13 @@ class Writing(util.LoRATestCase):
                     'user_key': 'AD',
                     'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     "validity": {
-                        'from': '1932-05-12T00:00:00+01:00',
+                        'from': '1932-05-12',
                         'to': None,
                     },
                 },
                 "data": {
                     "validity": {
-                        "to": '2020-01-01T00:00:00+01:00',
+                        "to": '2019-12-31',
                     },
                 },
             }],
@@ -737,8 +737,8 @@ class Writing(util.LoRATestCase):
               'user_key': 'AD',
               'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
               "validity": {
-                  'from': '1932-05-12T00:00:00+01:00',
-                  'to': '2020-01-01T00:00:00+01:00'},
+                  'from': '1932-05-12',
+                  'to': '2019-12-31'},
               },
              {'name': 'Lokal Rammearkitektur',
               'reference': None,
@@ -746,8 +746,8 @@ class Writing(util.LoRATestCase):
               'user_key': 'LoRa',
               'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
               "validity": {
-                  'from': '2016-01-01T00:00:00+01:00',
-                  'to': '2018-01-01T00:00:00+01:00'
+                  'from': '2016-01-01',
+                  'to': '2017-12-31'
               },
               }],
         )
@@ -764,8 +764,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
                     "validity": {
-                        'from': '2016-01-01T00:00:00+01:00',
-                        'to': '2018-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
+                        'to': '2017-12-31',
                     },
                 },
                 "data": {
@@ -784,8 +784,8 @@ class Writing(util.LoRATestCase):
               'user_key': 'AD',
               'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
               "validity": {
-                  'from': '1932-05-12T00:00:00+01:00',
-                  'to': '2020-01-01T00:00:00+01:00'},
+                  'from': '1932-05-12',
+                  'to': '2019-12-31'},
               },
              {'name': 'Lokal Rammearkitektur',
               'reference': None,
@@ -793,7 +793,7 @@ class Writing(util.LoRATestCase):
               'user_key': 'LoRa',
               'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
               "validity": {
-                  'from': '2016-01-01T00:00:00+01:00',
+                  'from': '2016-01-01',
                   'to': None
               },
               }],
@@ -811,14 +811,14 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
                     "validity": {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
                 "data": {
                     'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     "validity": {
-                        'to': '2016-06-01T00:00:00+02:00',
+                        'to': '2016-05-31',
                     },
                 }
             }],
@@ -834,8 +834,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'AD',
                     'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     "validity": {
-                        'from': '2016-01-01T00:00:00+01:00',
-                        'to': '2016-06-01T00:00:00+02:00'
+                        'from': '2016-01-01',
+                        'to': '2016-05-31'
                     },
                 },
             ],
@@ -849,8 +849,8 @@ class Writing(util.LoRATestCase):
               'user_key': 'AD',
               'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
               "validity": {
-                  'from': '1932-05-12T00:00:00+01:00',
-                  'to': '2020-01-01T00:00:00+01:00'},
+                  'from': '1932-05-12',
+                  'to': '2019-12-31'},
               }],
         )
 
@@ -871,8 +871,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'AD',
                     'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     "validity": {
-                        'from': '2016-01-01T00:00:00+01:00',
-                        'to': '2016-06-01T00:00:00+02:00'
+                        'from': '2016-01-01',
+                        'to': '2016-05-31'
                     },
                 },
                 "data": {
@@ -893,8 +893,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'AD',
                     'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     "validity": {
-                        'from': '1932-05-12T00:00:00+01:00',
-                        'to': '2020-01-01T00:00:00+01:00',
+                        'from': '1932-05-12',
+                        'to': '2019-12-31',
                     },
                 },
                 {
@@ -904,11 +904,47 @@ class Writing(util.LoRATestCase):
                     'user_key': 'AD',
                     'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
                     "validity": {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
             ],
+        )
+
+    @freezegun.freeze_time('2018-03-22', tz_offset=1)
+    def test_but_not_midnight(self):
+        self.load_sample_structures()
+
+        self.assertRequestResponse(
+            '/service/e/53181ed2-f1de-4c4a-a8fd-ab358c2c454a/details/it',
+            [],
+        )
+
+        self.assertRequestResponse(
+            '/service/e/53181ed2-f1de-4c4a-a8fd-ab358c2c454a/create',
+            {
+                'description':
+                "'2018-03-01T01:00:00+01:00' is not at midnight!",
+                'error': True,
+                'error_key': 'E_INVALID_INPUT',
+                'status': 400,
+            },
+            status_code=400,
+            json=[{
+                "type": "it",
+                "itsystem": {
+                    "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697"
+                },
+                "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
+                "validity": {
+                    "from": "2018-03-01T00:00:00Z"
+                }
+            }],
+        )
+
+        self.assertRequestResponse(
+            '/service/e/53181ed2-f1de-4c4a-a8fd-ab358c2c454a/details/it',
+            [],
         )
 
     @freezegun.freeze_time('2018-03-22', tz_offset=1)
@@ -930,7 +966,7 @@ class Writing(util.LoRATestCase):
                 },
                 "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                 "validity": {
-                    "from": "2018-03-01T00:00:00.000Z"
+                    "from": "2018-03-01"
                 }
             }],
         )
@@ -945,7 +981,7 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                     "validity": {
-                        "from": "2018-03-01T01:00:00+01:00",
+                        "from": "2018-03-01",
                         "to": None,
                     }
                 }
@@ -965,7 +1001,7 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                     "validity": {
-                        "from": "2018-03-01T01:00:00+01:00",
+                        "from": "2018-03-01",
                         "to": None
                     }
                 },
@@ -975,8 +1011,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                     "validity": {
-                        "from": "2018-03-01T00:00:00.000Z",
-                        "to": "2018-04-01T00:00:00.000Z"
+                        "from": "2018-03-01",
+                        "to": "2018-03-31"
                     },
                     "type": "it",
                     "itsystem": {
@@ -996,8 +1032,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                     "validity": {
-                        "from": "2018-03-01T01:00:00+01:00",
-                        "to": "2018-04-01T02:00:00+02:00",
+                        "from": "2018-03-01",
+                        "to": "2018-03-31",
                     }
                 }
             ],
@@ -1016,8 +1052,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     "uuid": "0872fb72-926d-4c5c-a063-ff800b8ee697",
                     "validity": {
-                        "from": "2018-03-01T01:00:00+01:00",
-                        "to": "2018-04-01T02:00:00+02:00"
+                        "from": "2018-03-01",
+                        "to": "2018-03-31"
                     }
                 },
                 "data": {
@@ -1027,8 +1063,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'LoRa',
                     "uuid": "59c135c9-2b15-41cc-97c8-b5dff7180beb",
                     "validity": {
-                        "from": "2018-03-01T00:00:00.000Z",
-                        "to": "2018-04-01T00:00:00.000Z"
+                        "from": "2018-03-01",
+                        "to": "2018-03-31"
                     },
                     "type": "it",
                     "itsystem": {
@@ -1048,8 +1084,8 @@ class Writing(util.LoRATestCase):
                     'user_key': 'AD',
                     "uuid": "59c135c9-2b15-41cc-97c8-b5dff7180beb",
                     "validity": {
-                        "from": "2018-03-01T01:00:00+01:00",
-                        "to": "2018-04-01T02:00:00+02:00",
+                        "from": "2018-03-01",
+                        "to": "2018-03-31",
                     }
                 }
             ],
@@ -1074,120 +1110,120 @@ class Writing(util.LoRATestCase):
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2017-12-15T01:00:00+01:00',
-                               'to': '2018-03-06T01:00:00+01:00'}},
+                  'validity': {'from': '2017-12-15',
+                               'to': '2018-03-05'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2017-12-15T01:00:00+01:00',
-                               'to': '2018-03-06T01:00:00+01:00'}},
+                  'validity': {'from': '2017-12-15',
+                               'to': '2018-03-05'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2017-12-15T01:00:00+01:00',
-                               'to': '2018-03-06T01:00:00+01:00'}},
+                  'validity': {'from': '2017-12-15',
+                               'to': '2018-03-05'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2017-12-15T01:00:00+01:00',
-                               'to': '2018-03-06T01:00:00+01:00'}},
+                  'validity': {'from': '2017-12-15',
+                               'to': '2018-03-05'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2017-12-15T01:00:00+01:00',
-                               'to': '2018-03-06T01:00:00+01:00'}},
+                  'validity': {'from': '2017-12-15',
+                               'to': '2018-03-05'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2017-12-15T01:00:00+01:00',
-                               'to': '2018-03-06T01:00:00+01:00'}},
+                  'validity': {'from': '2017-12-15',
+                               'to': '2018-03-05'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-02T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-02',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-07T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-07',
+                               'to': '2018-03-07'}},
                  {'name': 'Active Directory',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-07T00:00:00+01:00',
-                               'to': '2018-03-08T00:00:00+01:00'}},
+                  'validity': {'from': '2018-03-07',
+                               'to': '2018-03-07'}},
                  {'name': 'Lokal Rammearkitektur',
                   'reference': None,
                   'system_type': None,
                   'user_key': 'LoRa',
                   'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
-                  'validity': {'from': '2018-03-08T00:00:00+01:00',
-                               'to': '2018-03-09T00:00:00+01:00'}}],
+                  'validity': {'from': '2018-03-08',
+                               'to': '2018-03-08'}}],
 
             )
 
@@ -1199,7 +1235,7 @@ class Writing(util.LoRATestCase):
                   'system_type': None,
                   'user_key': 'AD',
                   'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
-                  'validity': {'from': '2018-03-05T01:00:00+01:00',
+                  'validity': {'from': '2018-03-05',
                                'to': None}}],
             )
 
@@ -1245,7 +1281,7 @@ class Reading(util.LoRATestCase):
               'user_key': 'AD',
               'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
               "validity": {
-                  'from': '1932-05-12T00:00:00+01:00',
+                  'from': '1932-05-12',
                   'to': None},
               },
              {'name': 'Lokal Rammearkitektur',
@@ -1254,8 +1290,8 @@ class Reading(util.LoRATestCase):
               'user_key': 'LoRa',
               'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
               "validity": {
-                  'from': '2016-01-01T00:00:00+01:00',
-                  'to': '2018-01-01T00:00:00+01:00'
+                  'from': '2016-01-01',
+                  'to': '2017-12-31'
               },
               }],
         )
@@ -1281,7 +1317,7 @@ class Reading(util.LoRATestCase):
               'user_key': 'AD',
               'uuid': '59c135c9-2b15-41cc-97c8-b5dff7180beb',
               "validity": {
-                  'from': '1932-05-12T00:00:00+01:00',
+                  'from': '1932-05-12',
                   'to': None
               },
               }],
@@ -1296,8 +1332,8 @@ class Reading(util.LoRATestCase):
               'user_key': 'LoRa',
               'uuid': '0872fb72-926d-4c5c-a063-ff800b8ee697',
               "validity": {
-                  'from': '2016-01-01T00:00:00+01:00',
-                  'to': '2018-01-01T00:00:00+01:00'
+                  'from': '2016-01-01',
+                  'to': '2017-12-31'
               },
               }],
         )

--- a/backend/tests/test_integration_leave.py
+++ b/backend/tests/test_integration_leave.py
@@ -36,8 +36,8 @@ class Tests(util.LoRATestCase):
                 "leave_type": {
                     'uuid': leave_type},
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -145,7 +145,7 @@ class Tests(util.LoRATestCase):
                     'uuid': leave_type
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
+                    "from": "2017-12-01",
                 },
             }
         ]
@@ -265,8 +265,8 @@ class Tests(util.LoRATestCase):
                 "leave_type": {
                     'uuid': leave_type},
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -299,7 +299,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -415,7 +415,7 @@ class Tests(util.LoRATestCase):
             "uuid": leave_uuid,
             "data": {
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -522,7 +522,7 @@ class Tests(util.LoRATestCase):
             "uuid": leave_uuid,
             "original": {
                 "validity": {
-                    "from": "2017-01-01 00:00:00+01",
+                    "from": "2017-01-01",
                     "to": None
                 },
                 "org_unit": {'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"},
@@ -537,7 +537,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "5991f9c2-9d82-45d5-9818-edf26fcc6d8b"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -656,8 +656,8 @@ class Tests(util.LoRATestCase):
                     'uuid': "bcd05828-cc10-48b1-bc48-2f0d204859b2"
                 },
                 "validity": {
-                    "from": "2000-04-01T00:00:00+02",
-                    "to": "2000-04-02T00:00:00+02",
+                    "from": "2000-04-01",
+                    "to": "2000-04-01",
                 },
             },
         }]
@@ -685,7 +685,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-12-01T00:00:00+01"
+                "from": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_leave.py
+++ b/backend/tests/test_integration_leave.py
@@ -685,7 +685,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-11-30"
+                "to": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_manager.py
+++ b/backend/tests/test_integration_manager.py
@@ -61,8 +61,8 @@ class Tests(util.LoRATestCase):
                     "uuid": "c78eb6f7-8a9e-40b3-ac80-36b9f371c3e0"
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -231,7 +231,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -248,8 +248,8 @@ class Tests(util.LoRATestCase):
                 }],
                 'uuid': managerid,
                 'validity': {
-                    'from': '2017-12-01T00:00:00+01:00',
-                    'to': '2017-12-02T00:00:00+01:00',
+                    'from': '2017-12-01',
+                    'to': '2017-12-01',
                 },
             }],
         )
@@ -276,7 +276,7 @@ class Tests(util.LoRATestCase):
                     "uuid": "c78eb6f7-8a9e-40b3-ac80-36b9f371c3e0"
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
+                    "from": "2017-12-01",
                 },
             }
         ]
@@ -421,7 +421,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -438,7 +438,7 @@ class Tests(util.LoRATestCase):
                 }],
                 'uuid': managerid,
                 'validity': {
-                    'from': '2017-12-01T00:00:00+01:00', 'to': None,
+                    'from': '2017-12-01', 'to': None,
                 },
             }],
         )
@@ -456,8 +456,8 @@ class Tests(util.LoRATestCase):
                 "type": "manager",
                 "org_unit": {'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"},
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -563,7 +563,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -574,8 +574,8 @@ class Tests(util.LoRATestCase):
                 'responsibility': [],
                 'uuid': managerid,
                 'validity': {
-                    'from': '2017-12-01T00:00:00+01:00',
-                    'to': '2017-12-02T00:00:00+01:00',
+                    'from': '2017-12-01',
+                    'to': '2017-12-01',
                 },
             }],
         )
@@ -631,8 +631,8 @@ class Tests(util.LoRATestCase):
                     "uuid": "c78eb6f7-8a9e-40b3-ac80-36b9f371c3e0"
                 },
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -811,7 +811,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -837,8 +837,8 @@ class Tests(util.LoRATestCase):
                 ],
                 'uuid': managerid,
                 'validity': {
-                    'from': '2017-12-01T00:00:00+01:00',
-                    'to': '2017-12-02T00:00:00+01:00',
+                    'from': '2017-12-01',
+                    'to': '2017-12-01',
                 },
             }],
         )
@@ -867,7 +867,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "e34d4426-9845-4c72-b31e-709be85d6fa2"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -1075,7 +1075,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -1092,8 +1092,8 @@ class Tests(util.LoRATestCase):
                 }],
                 'uuid': '05609702-977f-4869-9fb4-50ad74c6999a',
                 'validity': {
-                    'from': '2017-01-01T00:00:00+01:00',
-                    'to': '2018-04-01T00:00:00+02:00',
+                    'from': '2017-01-01',
+                    'to': '2018-03-31',
                 },
             }],
         )
@@ -1133,7 +1133,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'fil',
                     'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                        'from': '2016-01-01', 'to': None,
                     },
                 },
                 'person': {
@@ -1149,7 +1149,7 @@ class Tests(util.LoRATestCase):
                 }],
                 'uuid': manager_uuid,
                 'validity': {
-                    'from': '2018-04-01T00:00:00+02:00', 'to': None,
+                    'from': '2018-04-01', 'to': None,
                 },
             }],
         )
@@ -1179,7 +1179,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "32547559-cfc1-4d97-94c6-70b192eff825"
                 },
                 "validity": {
-                    "from": "2017-01-01 00:00:00+01:00",
+                    "from": "2017-01-01",
                     "to": None,
                 },
             },
@@ -1207,7 +1207,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "e34d4426-9845-4c72-b31e-709be85d6fa2"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -1432,7 +1432,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'fil',
                     'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -1449,7 +1449,7 @@ class Tests(util.LoRATestCase):
                 }],
                 'uuid': '05609702-977f-4869-9fb4-50ad74c6999a',
                 'validity': {
-                    'from': '2018-04-01T00:00:00+02:00', 'to': None,
+                    'from': '2018-04-01', 'to': None,
                 },
             }],
         )
@@ -1474,7 +1474,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"
                 }],
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -1630,7 +1630,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-12-01T00:00:00+01"
+                "from": "2017-11-30"
             }
         }
 
@@ -1799,7 +1799,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -1816,8 +1816,8 @@ class Tests(util.LoRATestCase):
                 }],
                 'uuid': '05609702-977f-4869-9fb4-50ad74c6999a',
                 'validity': {
-                    'from': '2017-01-01T00:00:00+01:00',
-                    'to': '2017-12-01T00:00:00+01:00',
+                    'from': '2017-01-01',
+                    'to': '2017-11-30',
                 },
             }],
         )
@@ -1974,7 +1974,7 @@ class Tests(util.LoRATestCase):
             'org_unit': {'name': 'Humanistisk fakultet',
                          'user_key': 'hum',
                          'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
-                         'validity': {'from': '2016-01-01T00:00:00+01:00',
+                         'validity': {'from': '2016-01-01',
                                       'to': None}},
             'person': {'name': 'Anders And',
                        'uuid': '53181ed2-f1de-4c4a-a8fd-ab358c2c454a'},
@@ -1986,7 +1986,7 @@ class Tests(util.LoRATestCase):
                 'uuid': '4311e351-6a3c-4e7e-ae60-8a3b2938fbd6',
             }],
             'uuid': '05609702-977f-4869-9fb4-50ad74c6999a',
-            'validity': {'from': '2017-01-01T00:00:00+01:00',
+            'validity': {'from': '2017-01-01',
                          'to': None}
         }]
 
@@ -2024,7 +2024,7 @@ class Tests(util.LoRATestCase):
                         'uuid': "ca76a441-6226-404f-88a9-31e02e420e52"
                     }],
                     "validity": {
-                        "from": "2016-04-01T00:00:00+02",
+                        "from": "2016-04-01",
                     },
                 },
             }])
@@ -2049,7 +2049,7 @@ class Tests(util.LoRATestCase):
             for m in expected_changed_lora[g][f]:
                 m['virkning']['from'] = '2016-04-01 00:00:00+02'
 
-        expected_mora[0]['validity']['from'] = '2016-04-01T00:00:00+02:00'
+        expected_mora[0]['validity']['from'] = '2016-04-01'
         expected_mora[0]['responsibility'] = [{
             'example': None,
             'name': 'Institut',
@@ -2179,7 +2179,7 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hum',
                         'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -2205,7 +2205,7 @@ class Tests(util.LoRATestCase):
                     ],
                     'uuid': '05609702-977f-4869-9fb4-50ad74c6999a',
                     'validity': {
-                        'from': '2017-01-01T00:00:00+01:00',
+                        'from': '2017-01-01',
                         'to': None,
                     },
                 },

--- a/backend/tests/test_integration_manager.py
+++ b/backend/tests/test_integration_manager.py
@@ -1630,7 +1630,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-11-30"
+                "to": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_org_unit.py
+++ b/backend/tests/test_integration_org_unit.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
+import unittest
 from unittest.mock import patch
 
 import freezegun
@@ -1863,7 +1864,7 @@ class Tests(util.LoRATestCase):
                 'child_units': [
                     {
                         'child_count': 0,
-                        'name': 'Afdeling for Fortidshistorik',
+                        'name': 'Afdeling for Samtidshistorik',
                         'user_key': 'frem',
                         'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                         'validity': {
@@ -2071,4 +2072,209 @@ class Tests(util.LoRATestCase):
                 }
             },
             message='No terminating on creation date!'
+        )
+
+    @unittest.expectedFailure
+    @freezegun.freeze_time('2018-09-11', tz_offset=2)
+    def test_terminating_complex_org_unit(self):
+        self.load_sample_structures()
+
+        # alas, this import fails due to overzealous validation :(
+        unitid = util.load_fixture('organisation/organisationenhed',
+                                   'very-edited-unit.json')
+
+        with self.subTest('prerequisites'):
+            self.assertRequestResponse(
+                '/service/ou/{}'.format(unitid) +
+                '/details/org_unit?validity=past',
+                [
+                    {
+                        "name": "AlexTestah",
+                        "org": {
+                            "name": "Aarhus Universitet",
+                            "user_key": "AU",
+                            "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                        },
+                        "org_unit_type": {
+                            "example": None,
+                            "name": "Afdeling",
+                            "scope": None,
+                            "user_key": "afd",
+                            "uuid": "32547559-cfc1-4d97-94c6-70b192eff825"
+                        },
+                        "parent": {
+                            "name": "Overordnet Enhed",
+                            "user_key": "root",
+                            "uuid": "2874e1dc-85e6-4269-823a-e1125484dfd3",
+                            "validity": {
+                                "from": "2016-01-01",
+                                "to": None
+                            }
+                        },
+                        "user_key":
+                        "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+                        "uuid": unitid,
+                        "validity": {
+                            "from": "2018-08-01",
+                            "to": "2018-08-22"
+                        }
+                    },
+                    {
+                        "name": "AlexTestikah",
+                        "org": {
+                            "name": "Aarhus Universitet",
+                            "user_key": "AU",
+                            "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                        },
+                        "org_unit_type": {
+                            "example": None,
+                            "name": "Afdeling",
+                            "scope": None,
+                            "user_key": "afd",
+                            "uuid": "32547559-cfc1-4d97-94c6-70b192eff825"
+                        },
+                        "parent": {
+                            "name": "Overordnet Enhed",
+                            "user_key": "root",
+                            "uuid": "2874e1dc-85e6-4269-823a-e1125484dfd3",
+                            "validity": {
+                                "from": "2016-01-01",
+                                "to": None
+                            }
+                        },
+                        "user_key": "AlexTestah "
+                        "95c30cd4-1a5c-4025-a23d-430acf018178",
+                        "uuid": unitid,
+                        "validity": {
+                            "from": "2018-08-23",
+                            "to": "2018-08-23"
+                        }
+                    },
+                    {
+                        "name": "AlexTestikah",
+                        "org": {
+                            "name": "Aarhus Universitet",
+                            "user_key": "AU",
+                            "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                        },
+                        "org_unit_type": {
+                            "example": None,
+                            "name": "Fakultet",
+                            "scope": None,
+                            "user_key": "fak",
+                            "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6"
+                        },
+                        "parent": {
+                            "name": "Samfundsvidenskabelige fakultet",
+                            "user_key": "samf",
+                            "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
+                            "validity": {
+                                "from": "2017-01-01",
+                                "to": None
+                            }
+                        },
+                        "user_key":
+                        "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+                        "uuid": unitid,
+                        "validity": {
+                            "from": "2018-08-24",
+                            "to": "2018-08-31"
+                        }
+                    }
+                ],
+            )
+
+            self.assertRequestResponse(
+                '/service/ou/{}'.format(unitid) +
+                '/details/org_unit?validity=present',
+                [{
+                    "name": "AlexTest",
+                    "org": {
+                        "name": "Aarhus Universitet",
+                        "user_key": "AU",
+                        "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                    },
+                    "org_unit_type": {
+                        "example": None,
+                        "name": "Fakultet",
+                        "scope": None,
+                        "user_key": "fak",
+                        "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6"
+                    },
+                    "parent": {
+                        "name": "Samfundsvidenskabelige fakultet",
+                        "user_key": "samf",
+                        "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
+                        "validity": {
+                            "from": "2017-01-01",
+                            "to": None
+                        }
+                    },
+                    "user_key":
+                    "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+                    "uuid": unitid,
+                    "validity": {
+                        "from": "2018-09-01",
+                        "to": None,
+                    }
+                }],
+            )
+
+            self.assertRequestResponse(
+                '/service/ou/{}'.format(unitid) +
+                '/details/org_unit?validity=future',
+                [],
+            )
+
+        payload = {
+            "validity": {
+                "from": "2018-09-30"
+            }
+        }
+
+        self.assertRequestResponse(
+            '/service/ou/{}/terminate'.format(unitid),
+            unitid,
+            json=payload)
+
+        self.assertRequestResponse(
+            '/service/ou/{}'.format(unitid) +
+            '/details/org_unit?validity=present',
+            [{
+                "name": "AlexTest",
+                "org": {
+                    "name": "Aarhus Universitet",
+                    "user_key": "AU",
+                    "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
+                },
+                "org_unit_type": {
+                    "example": None,
+                    "name": "Fakultet",
+                    "scope": None,
+                    "user_key": "fak",
+                    "uuid": "4311e351-6a3c-4e7e-ae60-8a3b2938fbd6"
+                },
+                "parent": {
+                    "name": "Samfundsvidenskabelige fakultet",
+                    "user_key": "samf",
+                    "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
+                    "validity": {
+                        "from": "2017-01-01",
+                        "to": None
+                    }
+                },
+                "user_key":
+                "AlexTestah 95c30cd4-1a5c-4025-a23d-430acf018178",
+                "uuid": unitid,
+                "validity": {
+                    "from": "2018-09-01",
+                    "to": "2018-09-30",
+                }
+            }],
+        )
+
+        self.assertRequestResponse(
+            '/service/ou/{}'.format(unitid) +
+            '/details/org_unit?validity=future',
+            [],
         )

--- a/backend/tests/test_integration_org_unit.py
+++ b/backend/tests/test_integration_org_unit.py
@@ -1964,7 +1964,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2016-10-21"
+                "to": "2016-10-21"
             }
         }
 
@@ -2023,7 +2023,7 @@ class Tests(util.LoRATestCase):
             status_code=404,
             json={
                 "validity": {
-                    "from": "2016-12-31"
+                    "to": "2016-12-31"
                 }
             },
         )
@@ -2057,7 +2057,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2017-01-01"
+                    "to": "2017-01-01"
                 }
             },
         )
@@ -2102,7 +2102,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2017-05-31"
+                    "to": "2017-05-31"
                 }
             },
         )
@@ -2137,7 +2137,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2018-12-31"
+                    "to": "2018-12-31"
                 }
             },
         )
@@ -2152,7 +2152,7 @@ class Tests(util.LoRATestCase):
                 unitid,
                 json={
                     "validity": {
-                        "from": "2018-12-31"
+                        "to": "2018-12-31"
                     }
                 },
             )
@@ -2176,7 +2176,7 @@ class Tests(util.LoRATestCase):
             json={
                 "validity": {
                     # inclusion of timestamp is deliberate
-                    "from": "2018-12-31T00:00:00+01"
+                    "to": "2018-12-31T00:00:00+01"
                 }
             },
         )
@@ -2200,7 +2200,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "1999-12-31"
+                    "to": "1999-12-31"
                 }
             },
         )
@@ -2224,7 +2224,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2099-12-31"
+                    "to": "2099-12-31"
                 }
             },
         )
@@ -2248,7 +2248,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2015-12-31"
+                    "to": "2015-12-31"
                 }
             },
             message='No terminating on creation date!'
@@ -2408,7 +2408,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2018-09-30"
+                "to": "2018-09-30"
             }
         }
 

--- a/backend/tests/test_integration_org_unit.py
+++ b/backend/tests/test_integration_org_unit.py
@@ -43,8 +43,8 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                     "org": {
@@ -53,8 +53,8 @@ class Tests(util.LoRATestCase):
                         "uuid": "456362c4-0ee4-4e5e-a72c-751239745e62"
                     },
                     "validity": {
-                        "from": "2016-01-01T00:00:00+01:00",
-                        "to": "2017-01-01T00:00:00+01:00"
+                        "from": "2016-01-01",
+                        "to": "2016-12-31"
                     }
                 }
             ],
@@ -85,13 +85,13 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                     "validity": {
-                        "from": "2017-01-01T00:00:00+01:00",
-                        "to": "2018-01-01T00:00:00+01:00"
+                        "from": "2017-01-01",
+                        "to": "2017-12-31"
                     }
                 }
             ],
@@ -122,13 +122,13 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                     "validity": {
-                        "from": "2018-01-01T00:00:00+01:00",
-                        "to": "2019-01-01T00:00:00+01:00"
+                        "from": "2018-01-01",
+                        "to": "2018-12-31"
                     }
                 }
             ],
@@ -159,13 +159,13 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
-                        'to': '2017-01-01T00:00:00+01:00'
+                        'from': '2016-01-01',
+                        'to': '2016-12-31'
                     }
                 },
                 {
@@ -189,13 +189,13 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                     'validity': {
-                        'from': '2017-01-01T00:00:00+01:00',
-                        'to': '2018-01-01T00:00:00+01:00'
+                        'from': '2017-01-01',
+                        'to': '2017-12-31'
                     }
                 },
                 {
@@ -219,13 +219,13 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                     'validity': {
-                        'from': '2018-01-01T00:00:00+01:00',
-                        'to': '2019-01-01T00:00:00+01:00'
+                        'from': '2018-01-01',
+                        'to': '2018-12-31'
                     }
                 }
             ],
@@ -280,8 +280,8 @@ class Tests(util.LoRATestCase):
                 },
             ],
             "validity": {
-                "from": "2016-02-04T00:00:00+01",
-                "to": "2017-10-22T00:00:00+02",
+                "from": "2016-02-04",
+                "to": "2017-10-21",
             }
         }
 
@@ -403,15 +403,15 @@ class Tests(util.LoRATestCase):
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
                 'user_key': 'Fake Corp f494ad89-039d-478e-91f2-a63566554bd6',
                 'uuid': unitid,
                 'validity': {
-                    'from': '2016-02-04T00:00:00+01:00',
-                    'to': '2017-10-22T00:00:00+02:00',
+                    'from': '2016-02-04',
+                    'to': '2017-10-21',
                 }
             },
         )
@@ -466,8 +466,8 @@ class Tests(util.LoRATestCase):
                 },
             ],
             "validity": {
-                "from": "2010-02-04T00:00:00+01",
-                "to": "2017-10-22T00:00:00+02",
+                "from": "2010-02-04",
+                "to": "2017-10-21",
             }
         }
 
@@ -478,10 +478,10 @@ class Tests(util.LoRATestCase):
             'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
             'org_unit_uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
             'status': 400,
-            'valid_from': '2016-01-01T00:00:00+01:00',
+            'valid_from': '2016-01-01',
             'valid_to': None,
-            'wanted_valid_from': '2010-02-04T00:00:00+01:00',
-            'wanted_valid_to': '2017-10-22T00:00:00+02:00'
+            'wanted_valid_from': '2010-02-04',
+            'wanted_valid_to': '2017-10-21'
         }
 
         self.assertRequestResponse('/service/ou/create', expected,
@@ -513,7 +513,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "79e15798-7d6d-4e85-8496-dcc8887a1c1a"
                 },
                 "validity": {
-                    "from": "2017-01-01T00:00:00+01",
+                    "from": "2017-01-01",
                 },
             },
         }
@@ -647,7 +647,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "79e15798-7d6d-4e85-8496-dcc8887a1c1a"
                 },
                 "validity": {
-                    "from": "2017-01-01T00:00:00+01",
+                    "from": "2017-01-01",
                 },
             },
         }
@@ -785,9 +785,9 @@ class Tests(util.LoRATestCase):
                     'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                     'org_unit_uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                     'status': 400,
-                    'valid_from': '2016-01-01T00:00:00+01:00',
+                    'valid_from': '2016-01-01',
                     'valid_to': None,
-                    'wanted_valid_from': '2010-01-01T00:00:00+01:00',
+                    'wanted_valid_from': '2010-01-01',
                     'wanted_valid_to': None,
                 },
                 status_code=400,
@@ -819,7 +819,7 @@ class Tests(util.LoRATestCase):
                             'user_key': 'root',
                             'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
                                 'to': None,
                             },
                         },
@@ -973,7 +973,7 @@ class Tests(util.LoRATestCase):
             ],
             "validity": {
                 "from": "2017-01-01",
-                "to": "2018-01-01",
+                "to": "2017-12-31",
             }
         }
 
@@ -1134,7 +1134,7 @@ class Tests(util.LoRATestCase):
             "data": {
                 "name": "Filosofisk Institut II",
                 "validity": {
-                    "from": "2018-01-01T00:00:00+01",
+                    "from": "2018-01-01",
                 },
             },
         }
@@ -1277,7 +1277,7 @@ class Tests(util.LoRATestCase):
                 "data": {
                     "name": "Whatever",
                     "validity": {
-                        "from": "2016-01-01T00:00:00+01",
+                        "from": "2016-01-01",
                     },
                 },
             },
@@ -1310,14 +1310,14 @@ class Tests(util.LoRATestCase):
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
                 'user_key': 'samf',
                 'uuid': org_unit_uuid,
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
             }],
         )
@@ -1341,7 +1341,7 @@ class Tests(util.LoRATestCase):
                     "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0"
                 },
                 "validity": {
-                    "from": "2017-07-01T00:00:00+02",
+                    "from": "2017-07-01",
                 },
             },
         }
@@ -1476,7 +1476,7 @@ class Tests(util.LoRATestCase):
                     "uuid": "85715fc7-925d-401b-822d-467eb4b163b6"
                 },
                 "validity": {
-                    "from": "2017-07-01T00:00:00+02",
+                    "from": "2017-07-01",
                 },
             },
         }
@@ -1512,16 +1512,16 @@ class Tests(util.LoRATestCase):
                     'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                     'org_unit_uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                     'status': 400,
-                    'valid_from': '2016-01-01T00:00:00+01:00',
-                    'valid_to': '2019-01-01T00:00:00+01:00',
-                    'wanted_valid_from': '2016-01-01T00:00:00+01:00',
+                    'valid_from': '2016-01-01',
+                    'valid_to': '2018-12-31',
+                    'wanted_valid_from': '2016-01-01',
                     'wanted_valid_to': None
                 },
                 status_code=400,
                 json={
                     "data": {
                         "validity": {
-                            "from": "2016-01-01T00:00:00+01:00",
+                            "from": "2016-01-01",
                             "to": None,
                         },
                     },
@@ -1537,17 +1537,17 @@ class Tests(util.LoRATestCase):
                     'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                     'org_unit_uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                     'status': 400,
-                    'valid_from': '2016-01-01T00:00:00+01:00',
-                    'valid_to': '2019-01-01T00:00:00+01:00',
-                    'wanted_valid_from': '2010-01-01T00:00:00+01:00',
-                    'wanted_valid_to': '2019-01-01T00:00:00+01:00',
+                    'valid_from': '2016-01-01',
+                    'valid_to': '2018-12-31',
+                    'wanted_valid_from': '2010-01-01',
+                    'wanted_valid_to': '2018-12-31',
                 },
                 status_code=400,
                 json={
                     "data": {
                         "validity": {
-                            "from": "2010-01-01T00:00:00+01:00",
-                            "to": "2019-01-01T00:00:00+01:00",
+                            "from": "2010-01-01",
+                            "to": "2018-12-31",
                         },
                     },
                 })
@@ -1565,7 +1565,7 @@ class Tests(util.LoRATestCase):
                     "uuid": "85715fc7-925d-401b-822d-467eb4b163b6"
                 },
                 "validity": {
-                    "from": "2017-07-01T00:00:00+02",
+                    "from": "2017-07-01",
                 },
             },
         }
@@ -1619,7 +1619,7 @@ class Tests(util.LoRATestCase):
                         'uuid': other_unit_uuid,
                     },
                     "validity": {
-                        "from": "2018-01-01T00:00:00+02",
+                        "from": "2018-01-01",
                     },
                 },
             },
@@ -1640,7 +1640,7 @@ class Tests(util.LoRATestCase):
                     'overordnet': [{
                         'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': 'infinity',
                         },
                     }],
@@ -1679,7 +1679,7 @@ class Tests(util.LoRATestCase):
                         'uuid': root_uuid,
                     },
                     "validity": {
-                        "from": "2018-01-01T00:00:00+02",
+                        "from": "2018-01-01",
                     },
                 },
             },
@@ -1702,7 +1702,7 @@ class Tests(util.LoRATestCase):
                         'uuid': root_uuid,
                     },
                     "validity": {
-                        "from": "2018-01-01T00:00:00+02",
+                        "from": "2018-01-01",
                     },
                 },
             },
@@ -1751,8 +1751,8 @@ class Tests(util.LoRATestCase):
                     "uuid": "85715fc7-925d-401b-822d-467eb4b163b6"
                 },
                 "validity": {
-                    "from": "2017-07-01T00:00:00+02",
-                    "to": "2015-07-01T00:0000+02",
+                    "from": "2017-07-01",
+                    "to": "2015-07-01",
                 },
             },
         }
@@ -1769,8 +1769,8 @@ class Tests(util.LoRATestCase):
                         'uuid': '85715fc7-925d-401b-822d-467eb4b163b6'
                     },
                     'validity': {
-                        'from': '2017-07-01T00:00:00+02',
-                        'to': '2015-07-01T00:0000+02'
+                        'from': '2017-07-01',
+                        'to': '2015-07-01'
                     }
                 },
             },
@@ -1784,7 +1784,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2016-10-22T00:00:00+02"
+                "from": "2016-10-21"
             }
         }
 
@@ -1810,12 +1810,12 @@ class Tests(util.LoRATestCase):
                  'parent': {'name': 'Humanistisk fakultet',
                             'user_key': 'hum',
                             'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
-                            'validity': {'from': '2016-01-01T00:00:00+01:00',
+                            'validity': {'from': '2016-01-01',
                                          'to': None}},
                  'user_key': 'fil',
                  'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
-                 'validity': {'from': '2016-01-01T00:00:00+01:00',
-                              'to': '2016-10-22T00:00:00+02:00'}}]
+                 'validity': {'from': '2016-01-01',
+                              'to': '2016-10-21'}}]
         )
 
         # Verify that we are no longer able to see org unit
@@ -1842,7 +1842,7 @@ class Tests(util.LoRATestCase):
             status_code=404,
             json={
                 "validity": {
-                    "from": "2017-01-01T00:00:00+02"
+                    "from": "2016-12-31"
                 }
             },
         )
@@ -1867,8 +1867,8 @@ class Tests(util.LoRATestCase):
                         'user_key': 'frem',
                         'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                 ],
@@ -1876,7 +1876,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2017-01-01T00:00:00+02"
+                    "from": "2017-01-01"
                 }
             },
         )
@@ -1902,7 +1902,7 @@ class Tests(util.LoRATestCase):
                         'user_key': 'fil',
                         'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -1912,8 +1912,8 @@ class Tests(util.LoRATestCase):
                         'user_key': 'hist',
                         'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     },
                 ],
@@ -1921,7 +1921,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2017-06-01T00:00:00+02"
+                    "from": "2017-05-31"
                 }
             },
         )
@@ -1947,7 +1947,7 @@ class Tests(util.LoRATestCase):
                         'user_key': 'fil',
                         'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     },
@@ -1956,7 +1956,7 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2019-01-01T00:00:00+01"
+                    "from": "2018-12-31"
                 }
             },
         )
@@ -1971,7 +1971,7 @@ class Tests(util.LoRATestCase):
                 unitid,
                 json={
                     "validity": {
-                        "from": "2019-01-01T00:00:00+01"
+                        "from": "2018-12-31"
                     }
                 },
             )
@@ -1994,7 +1994,8 @@ class Tests(util.LoRATestCase):
             status_code=400,
             json={
                 "validity": {
-                    "from": "2019-01-01T00:00:00+01"
+                    # inclusion of timestamp is deliberate
+                    "from": "2018-12-31T00:00:00+01"
                 }
             },
         )
@@ -2010,15 +2011,15 @@ class Tests(util.LoRATestCase):
                 'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                 'status': 400,
                 'org_unit_uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
-                'valid_from': '2016-01-01T00:00:00+01:00',
+                'valid_from': '2016-01-01',
                 'valid_to': None,
-                'wanted_valid_from': '1999-12-31T23:59:59.999999+01:00',
-                'wanted_valid_to': '2000-01-01T00:00:00+01:00',
+                'wanted_valid_from': '1999-12-31',
+                'wanted_valid_to': '1999-12-31',
             },
             status_code=400,
             json={
                 "validity": {
-                    "from": "2000-01-01T00:00:00+01"
+                    "from": "1999-12-31"
                 }
             },
         )
@@ -2034,15 +2035,15 @@ class Tests(util.LoRATestCase):
                 'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                 'status': 400,
                 'org_unit_uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
-                'valid_from': '2016-01-01T00:00:00+01:00',
-                'valid_to': '2019-01-01T00:00:00+01:00',
-                'wanted_valid_from': '2099-12-31T23:59:59.999999+01:00',
-                'wanted_valid_to': '2100-01-01T00:00:00+01:00',
+                'valid_from': '2016-01-01',
+                'valid_to': '2018-12-31',
+                'wanted_valid_from': '2099-12-31',
+                'wanted_valid_to': '2099-12-31',
             },
             status_code=400,
             json={
                 "validity": {
-                    "from": "2100-01-01T00:00:00+01"
+                    "from": "2099-12-31"
                 }
             },
         )
@@ -2058,15 +2059,15 @@ class Tests(util.LoRATestCase):
                 'error_key': 'V_DATE_OUTSIDE_ORG_UNIT_RANGE',
                 'status': 400,
                 'org_unit_uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
-                'valid_from': '2016-01-01T00:00:00+01:00',
-                'valid_to': '2019-01-01T00:00:00+01:00',
-                'wanted_valid_from': '2015-12-31T23:59:59.999999+01:00',
-                'wanted_valid_to': '2016-01-01T00:00:00+01:00',
+                'valid_from': '2016-01-01',
+                'valid_to': '2018-12-31',
+                'wanted_valid_from': '2015-12-31',
+                'wanted_valid_to': '2015-12-31',
             },
             status_code=400,
             json={
                 "validity": {
-                    "from": "2016-01-01 00:00:00+01"
+                    "from": "2015-12-31"
                 }
             },
             message='No terminating on creation date!'

--- a/backend/tests/test_integration_role.py
+++ b/backend/tests/test_integration_role.py
@@ -675,7 +675,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-11-30"
+                "to": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_role.py
+++ b/backend/tests/test_integration_role.py
@@ -31,8 +31,8 @@ class Tests(util.LoRATestCase):
                 "role_type": {
                     'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"},
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
-                    "to": "2017-12-02T00:00:00+01",
+                    "from": "2017-12-01",
+                    "to": "2017-12-01",
                 },
             }
         ]
@@ -149,7 +149,7 @@ class Tests(util.LoRATestCase):
                 "role_type": {
                     'uuid': "62ec821f-4179-4758-bfdf-134529d186e9"},
                 "validity": {
-                    "from": "2017-12-01T00:00:00+01",
+                    "from": "2017-12-01",
                 },
             }
         ]
@@ -282,7 +282,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "b688513d-11f7-4efc-b679-ab082a2055d0"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -413,7 +413,7 @@ class Tests(util.LoRATestCase):
             "uuid": role_uuid,
             "data": {
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -531,7 +531,7 @@ class Tests(util.LoRATestCase):
             "uuid": role_uuid,
             "original": {
                 "validity": {
-                    "from": "2017-01-01 00:00:00+01",
+                    "from": "2017-01-01",
                     "to": None
                 },
                 "org_unit": {'uuid': "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e"},
@@ -546,7 +546,7 @@ class Tests(util.LoRATestCase):
                     'uuid': "b688513d-11f7-4efc-b679-ab082a2055d0"
                 },
                 "validity": {
-                    "from": "2018-04-01T00:00:00+02",
+                    "from": "2018-04-01",
                 },
             },
         }]
@@ -675,7 +675,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2017-12-01T00:00:00+01"
+                "from": "2017-11-30"
             }
         }
 

--- a/backend/tests/test_integration_service.py
+++ b/backend/tests/test_integration_service.py
@@ -160,7 +160,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -183,7 +183,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'root',
                     'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -198,7 +198,7 @@ class Tests(util.LoRATestCase):
                     "user_key": "hum",
                     "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
                     "validity": {
-                        "from": "2016-01-01T00:00:00+01:00",
+                        "from": "2016-01-01",
                         "to": None,
                     },
                     "child_count": 2,
@@ -208,7 +208,7 @@ class Tests(util.LoRATestCase):
                     "user_key": "samf",
                     "uuid": "b688513d-11f7-4efc-b679-ab082a2055d0",
                     "validity": {
-                        "from": "2017-01-01T00:00:00+01:00",
+                        "from": "2017-01-01",
                         "to": None,
                     },
                     "child_count": 0,
@@ -225,8 +225,8 @@ class Tests(util.LoRATestCase):
                 'name': 'Afdeling for Samtidshistorik',
                 'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
-                    'to': '2019-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
+                    'to': '2018-12-31',
                 },
             },
             {
@@ -234,7 +234,7 @@ class Tests(util.LoRATestCase):
                 'name': 'Overordnet Enhed',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -243,7 +243,7 @@ class Tests(util.LoRATestCase):
                 'name': 'Filosofisk Institut',
                 'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -252,7 +252,7 @@ class Tests(util.LoRATestCase):
                 'name': 'Humanistisk fakultet',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
             },
@@ -261,7 +261,7 @@ class Tests(util.LoRATestCase):
                 'name': 'Samfundsvidenskabelige fakultet',
                 'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
                 'validity': {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None,
                 },
             },
@@ -270,8 +270,8 @@ class Tests(util.LoRATestCase):
                 'name': 'Historisk Institut',
                 'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
-                    'to': '2019-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
+                    'to': '2018-12-31',
                 },
             },
         ]
@@ -296,8 +296,8 @@ class Tests(util.LoRATestCase):
                             'name': 'Afdeling for Samtidshistorik',
                             'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
-                                'to': '2019-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
+                                'to': '2018-12-31',
                             },
                         },
                         {
@@ -305,7 +305,7 @@ class Tests(util.LoRATestCase):
                             'name': 'Filosofisk Institut',
                             'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
                                 'to': None,
                             },
                         },
@@ -326,8 +326,8 @@ class Tests(util.LoRATestCase):
                             'name': 'Afdeling for Samtidshistorik',
                             'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
-                                'to': '2019-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
+                                'to': '2018-12-31',
                             },
                         },
                         {
@@ -335,7 +335,7 @@ class Tests(util.LoRATestCase):
                             'name': 'Humanistisk fakultet',
                             'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
                                 'to': None,
                             },
                         },
@@ -344,8 +344,8 @@ class Tests(util.LoRATestCase):
                             'name': 'Historisk Institut',
                             'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
-                                'to': '2019-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
+                                'to': '2018-12-31',
                             },
                         },
                     ],
@@ -365,8 +365,8 @@ class Tests(util.LoRATestCase):
                             'name': 'Afdeling for Samtidshistorik',
                             'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
-                                'to': '2019-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
+                                'to': '2018-12-31',
                             },
                         },
                         {
@@ -374,7 +374,7 @@ class Tests(util.LoRATestCase):
                             'name': 'Filosofisk Institut',
                             'uuid': '85715fc7-925d-401b-822d-467eb4b163b6',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
                                 'to': None,
                             },
                         },
@@ -383,8 +383,8 @@ class Tests(util.LoRATestCase):
                             'name': 'Historisk Institut',
                             'uuid': 'da77153e-30f3-4dc2-a611-ee912a28d8aa',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
-                                'to': '2019-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
+                                'to': '2018-12-31',
                             },
                         },
                     ],
@@ -403,7 +403,7 @@ class Tests(util.LoRATestCase):
                             'name': 'Overordnet Enhed',
                             'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
                                 'to': None,
                             },
                         },
@@ -412,7 +412,7 @@ class Tests(util.LoRATestCase):
                             'name': 'Humanistisk fakultet',
                             'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                             'validity': {
-                                'from': '2016-01-01T00:00:00+01:00',
+                                'from': '2016-01-01',
                                 'to': None,
                             },
                         },
@@ -421,7 +421,7 @@ class Tests(util.LoRATestCase):
                             'name': 'Samfundsvidenskabelige fakultet',
                             'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
                             'validity': {
-                                'from': '2017-01-01T00:00:00+01:00',
+                                'from': '2017-01-01',
                                 'to': None,
                             },
                         },
@@ -441,8 +441,8 @@ class Tests(util.LoRATestCase):
                         'user_key': 'frem',
                         'uuid': '04c78fc2-72d2-4d02-b55f-807af19eac48',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
-                            'to': '2019-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
+                            'to': '2018-12-31',
                         },
                     }],
                     'offset': 0,
@@ -459,7 +459,7 @@ class Tests(util.LoRATestCase):
                         'user_key': 'root',
                         'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                         'validity': {
-                            'from': '2016-01-01T00:00:00+01:00',
+                            'from': '2016-01-01',
                             'to': None,
                         },
                     }],
@@ -490,7 +490,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
                 'org': {
@@ -530,7 +530,7 @@ class Tests(util.LoRATestCase):
                 },
                 'parent': None,
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 }
             }],
         )
@@ -563,7 +563,7 @@ class Tests(util.LoRATestCase):
                 },
                 'parent': None,
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00', 'to': None,
+                    'from': '2016-01-01', 'to': None,
                 },
             }],
         )
@@ -575,7 +575,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'root',
                 'uuid': '2874e1dc-85e6-4269-823a-e1125484dfd3',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None,
                 },
                 'org': {
@@ -600,13 +600,13 @@ class Tests(util.LoRATestCase):
               'name': 'Humanistisk fakultet',
               'user_key': 'hum',
               'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
-              'validity': {'from': '2016-01-01T00:00:00+01:00',
+              'validity': {'from': '2016-01-01',
                            'to': None}},
              {'child_count': 0,
               'name': 'Samfundsvidenskabelige fakultet',
               'user_key': 'samf',
               'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
-              'validity': {'from': '2017-01-01T00:00:00+01:00',
+              'validity': {'from': '2017-01-01',
                            'to': None}}],
         )
 
@@ -878,7 +878,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -895,7 +895,7 @@ class Tests(util.LoRATestCase):
                 },
                 'uuid': 'd000591f-8705-4324-897a-075e3623f37b',
                 "validity": {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None,
                 },
             },
@@ -956,7 +956,7 @@ class Tests(util.LoRATestCase):
                     'user_key': 'hum',
                     'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                     'validity': {
-                        'from': '2016-01-01T00:00:00+01:00',
+                        'from': '2016-01-01',
                         'to': None,
                     },
                 },
@@ -973,7 +973,7 @@ class Tests(util.LoRATestCase):
                 },
                 'uuid': '1b20d0b9-96a0-42a6-b196-293bb86e62e8',
                 "validity": {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None,
                 },
             },
@@ -1042,7 +1042,7 @@ class Tests(util.LoRATestCase):
                 },
                 'uuid': 'b807628c-030c-4f5f-a438-de41c1f26ba5',
                 "validity": {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None,
                 },
             },
@@ -1126,7 +1126,7 @@ class Tests(util.LoRATestCase):
                     "user_key": "hum",
                     "uuid": "9d07123e-47ac-4a9a-88c8-da82e3a4bc9e",
                     "validity": {
-                        "from": "2016-01-01T00:00:00+01:00",
+                        "from": "2016-01-01",
                         "to": None,
                     },
                 },
@@ -1146,7 +1146,7 @@ class Tests(util.LoRATestCase):
                 }],
                 'uuid': '05609702-977f-4869-9fb4-50ad74c6999a',
                 "validity": {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None,
                 },
             },
@@ -1526,7 +1526,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'hum',
                 'uuid': '9d07123e-47ac-4a9a-88c8-da82e3a4bc9e',
                 'validity': {
-                    'from': '2016-01-01T00:00:00+01:00',
+                    'from': '2016-01-01',
                     'to': None
                 }
             },
@@ -1536,7 +1536,7 @@ class Tests(util.LoRATestCase):
             },
             'uuid': 'd000591f-8705-4324-897a-075e3623f37b',
             'validity': {
-                'from': '2017-01-01T00:00:00+01:00',
+                'from': '2017-01-01',
                 'to': None
             }
         }, {
@@ -1559,7 +1559,7 @@ class Tests(util.LoRATestCase):
                 'user_key': 'samf',
                 'uuid': 'b688513d-11f7-4efc-b679-ab082a2055d0',
                 'validity': {
-                    'from': '2017-01-01T00:00:00+01:00',
+                    'from': '2017-01-01',
                     'to': None
                 }
             },
@@ -1569,7 +1569,7 @@ class Tests(util.LoRATestCase):
             },
             'uuid': '09e79d96-2904-444f-94b1-0e98b0b07e7c',
             'validity': {
-                'from': '2017-01-01T00:00:00+01:00',
+                'from': '2017-01-01',
                 'to': None
             }
         }]

--- a/backend/tests/test_integration_termination.py
+++ b/backend/tests/test_integration_termination.py
@@ -21,7 +21,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2000-12-01T00:00:00+01"
+                "from": "2000-12-01"
             }
         }
 

--- a/backend/tests/test_integration_termination.py
+++ b/backend/tests/test_integration_termination.py
@@ -21,7 +21,7 @@ class Tests(util.LoRATestCase):
 
         payload = {
             "validity": {
-                "from": "2000-12-01"
+                "to": "2000-12-01"
             }
         }
 

--- a/backend/tests/test_integration_validator.py
+++ b/backend/tests/test_integration_validator.py
@@ -29,7 +29,7 @@ class TestHelper(util.LoRATestCase):
         # Expire the parent from 2018-01-01
         payload = {
             'validity': {
-                'from': "2018-01-01"
+                'to': "2018-01-01"
             }
         }
 

--- a/backend/tests/test_integration_validator.py
+++ b/backend/tests/test_integration_validator.py
@@ -296,7 +296,7 @@ class TestIntegrationMoveOrgUnitValidator(TestHelper):
             )
 
     def test_should_return_false_when_candidate_parent_is_inactive(self):
-        move_date = '01-01-2018'
+        move_date = '01-01-2019'
         new_org_uuid = self.PARENT
 
         self.expire_org_unit(self.PARENT)

--- a/backend/tests/test_service_common.py
+++ b/backend/tests/test_service_common.py
@@ -66,15 +66,15 @@ class TestClass(util.TestCase):
                     {
                         'uuid': '1ebd2f10-df7b-42ca-93d9-3078a174c3f6',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2018-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2018-01-01T00:00:00+01:00'
                         }
                     },
                     {
                         'uuid': '6563c93d-48da-4375-a106-b05343f97915',
                         'virkning': {
-                            'from': '2018-01-01T00:00:00+00:00',
-                            'to': '2020-01-01T00:00:00+00:00'
+                            'from': '2018-01-01T00:00:00+01:00',
+                            'to': '2020-01-01T00:00:00+01:00'
                         }
                     },
                 ],
@@ -82,8 +82,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'eb936cf5-e72b-4aa9-9bd2-f773c462fa50',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2020-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2020-01-01T00:00:00+01:00'
                         }
                     }
                 ]
@@ -93,8 +93,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'ab9c5351-6448-4b6e-be02-eb3c16960884',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2020-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2020-01-01T00:00:00+01:00'
                         }
                     }
                 ]
@@ -104,8 +104,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'ab9c5351-6448-4b6e-be02-eb3c16960884',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2020-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2020-01-01T00:00:00+01:00'
                         }
                     }
                 ]
@@ -118,15 +118,15 @@ class TestClass(util.TestCase):
                     {
                         'uuid': '1ebd2f10-df7b-42ca-93d9-3078a174c3f6',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2017-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2017-01-01T00:00:00+01:00'
                         }
                     },
                     {
                         'uuid': '8525d022-e939-4d16-8378-2e46101a3a47',
                         'virkning': {
-                            'from': '2017-01-01T00:00:00+00:00',
-                            'to': '2021-01-01T00:00:00+00:00'
+                            'from': '2017-01-01T00:00:00+01:00',
+                            'to': '2021-01-01T00:00:00+01:00'
                         }
                     }
                 ],
@@ -134,15 +134,15 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'eb936cf5-e72b-4aa9-9bd2-f773c462fa50',
                         'virkning': {
-                            'from': '2016-01-01T00:00:00+00:00',
-                            'to': '2020-01-01T00:00:00+00:00'
+                            'from': '2016-01-01T00:00:00+01:00',
+                            'to': '2020-01-01T00:00:00+01:00'
                         }
                     },
                     {
                         'uuid': '6995b5db-5e66-4479-82d8-67045663eb79',
                         'virkning': {
-                            'from': '2017-01-01T00:00:00+00:00',
-                            'to': '2021-01-01T00:00:00+00:00'
+                            'from': '2017-01-01T00:00:00+01:00',
+                            'to': '2021-01-01T00:00:00+01:00'
                         }
                     }
                 ]
@@ -152,8 +152,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': '3251f325-a36f-4879-a150-2775cdc1b0fb',
                         'virkning': {
-                            'from': '2017-01-01T00:00:00+00:00',
-                            'to': '2021-01-01T00:00:00+00:00'
+                            'from': '2017-01-01T00:00:00+01:00',
+                            'to': '2021-01-01T00:00:00+01:00'
                         }
                     }
                 ]
@@ -162,8 +162,8 @@ class TestClass(util.TestCase):
 
         # Act
         actual_payload = common.update_payload(
-            '2017-01-01T00:00:00+00:00',
-            '2021-01-01T00:00:00+00:00',
+            '2017-01-01T00:00:00+01:00',
+            '2021-01-01T00:00:00+01:00',
             fields,
             original,
             {}
@@ -174,10 +174,10 @@ class TestClass(util.TestCase):
 
     def test_inactivates_correctly_when_diminishing_bounds(self):
         # Arrange
-        old_from = '2013-01-01T00:00:00+00:00'
-        old_to = '2016-01-01T00:00:00+00:00'
-        new_from = '2014-01-01T00:00:00+00:00'
-        new_to = '2015-01-01T00:00:00+00:00'
+        old_from = '2013-01-01T00:00:00+01:00'
+        old_to = '2016-01-01T00:00:00+01:00'
+        new_from = '2014-01-01T00:00:00+01:00'
+        new_to = '2015-01-01T00:00:00+01:00'
         payload = {
             'whatever': ['Should remain untouched'],
             'note': 'NOTE'
@@ -191,15 +191,15 @@ class TestClass(util.TestCase):
                     {
                         'gyldighed': 'Inaktiv',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                         }
                     },
                     {
                         'gyldighed': 'Inaktiv',
                         'virkning': {
-                            'from': '2015-01-01T00:00:00+00:00',
-                            'to': '2016-01-01T00:00:00+00:00',
+                            'from': '2015-01-01T00:00:00+01:00',
+                            'to': '2016-01-01T00:00:00+01:00',
                         }
                     }
                 ]
@@ -217,10 +217,10 @@ class TestClass(util.TestCase):
 
     def test_does_not_inactivate_when_expanding_bounds(self):
         # Arrange
-        old_from = '2014-01-01T00:00:00+00:00'
-        old_to = '2015-01-01T00:00:00+00:00'
-        new_from = '2013-01-01T00:00:00+00:00'
-        new_to = '2016-01-01T00:00:00+00:00'
+        old_from = '2014-01-01T00:00:00+01:00'
+        old_to = '2015-01-01T00:00:00+01:00'
+        new_from = '2013-01-01T00:00:00+01:00'
+        new_to = '2016-01-01T00:00:00+01:00'
         payload = {
             'whatever': ['Should remain untouched'],
             'note': 'NOTE'
@@ -242,10 +242,10 @@ class TestClass(util.TestCase):
 
     def test_does_not_inactivate_when_bounds_do_not_move(self):
         # Arrange
-        old_from = '2014-01-01T00:00:00+00:00'
-        old_to = '2015-01-01T00:00:00+00:00'
-        new_from = '2014-01-01T00:00:00+00:00'
-        new_to = '2015-01-01T00:00:00+00:00'
+        old_from = '2014-01-01T00:00:00+01:00'
+        old_to = '2015-01-01T00:00:00+01:00'
+        new_from = '2014-01-01T00:00:00+01:00'
+        new_to = '2015-01-01T00:00:00+01:00'
         payload = {
             'whatever': ['Should remain untouched'],
             'note': 'NOTE'
@@ -267,8 +267,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_aztm_times_are_inside_bounds(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2013-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2013-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -276,8 +276,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -285,8 +285,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -294,8 +294,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -338,8 +338,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_aztm_expanding_from_time(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2014-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2014-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -347,8 +347,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -356,8 +356,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -365,8 +365,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -396,21 +396,21 @@ class TestClass(util.TestCase):
             'test1': {'no': ['Me too'],
                       'test2': [{'uuid': 'HEJ1',
                                  'virkning': {
-                                     'from': '2010-01-01T00:00:00+00:00',
+                                     'from': '2010-01-01T00:00:00+01:00',
                                      'from_included': True,
-                                     'to': '2013-01-01T00:00:00+00:00',
+                                     'to': '2013-01-01T00:00:00+01:00',
                                      'to_included': False}},
                                 {'uuid': 'HEJ2',
                                  'virkning': {
-                                     'from': '2013-01-01T00:00:00+00:00',
+                                     'from': '2013-01-01T00:00:00+01:00',
                                      'from_included': True,
-                                     'to': '2014-01-01T00:00:00+00:00',
+                                     'to': '2014-01-01T00:00:00+01:00',
                                      'to_included': False}},
                                 {'uuid': 'HEJ3',
                                  'virkning': {
-                                     'from': '2014-01-01T00:00:00+00:00',
+                                     'from': '2014-01-01T00:00:00+01:00',
                                      'from_included': True,
-                                     'to': '2015-01-01T00:00:00+00:00',
+                                     'to': '2015-01-01T00:00:00+01:00',
                                      'to_included': False}}]},
             'whatever': ['I should remain untouched, please']}
 
@@ -424,8 +424,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_aztm_diminishing_from_time(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2012-07-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2012-07-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -433,8 +433,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -442,8 +442,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -451,8 +451,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -498,8 +498,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_aztm_expanding_to_time(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2017-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2017-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -507,8 +507,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -516,8 +516,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -525,8 +525,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -556,21 +556,21 @@ class TestClass(util.TestCase):
             'test1': {'no': ['Me too'],
                       'test2': [{'uuid': 'HEJ1',
                                  'virkning': {
-                                     'from': '2012-01-01T00:00:00+00:00',
+                                     'from': '2012-01-01T00:00:00+01:00',
                                      'from_included': True,
-                                     'to': '2013-01-01T00:00:00+00:00',
+                                     'to': '2013-01-01T00:00:00+01:00',
                                      'to_included': False}},
                                 {'uuid': 'HEJ2',
                                  'virkning': {
-                                     'from': '2013-01-01T00:00:00+00:00',
+                                     'from': '2013-01-01T00:00:00+01:00',
                                      'from_included': True,
-                                     'to': '2014-01-01T00:00:00+00:00',
+                                     'to': '2014-01-01T00:00:00+01:00',
                                      'to_included': False}},
                                 {'uuid': 'HEJ3',
                                  'virkning': {
-                                     'from': '2014-01-01T00:00:00+00:00',
+                                     'from': '2014-01-01T00:00:00+01:00',
                                      'from_included': True,
-                                     'to': '2017-01-01T00:00:00+00:00',
+                                     'to': '2017-01-01T00:00:00+01:00',
                                      'to_included': False}}]},
             'whatever': ['I should remain untouched, please']}
 
@@ -584,8 +584,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_aztm_diminishing_to_time(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2014-07-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2014-07-01T00:00:00+02:00')
 
         original = {
             'test1': {
@@ -593,8 +593,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -602,8 +602,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -611,8 +611,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -658,8 +658,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_ztm(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2000-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2020-07-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2000-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2020-07-01T00:00:00+02:00')
 
         original = {
             'test1': {
@@ -667,8 +667,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -676,8 +676,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -685,8 +685,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -722,8 +722,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -731,8 +731,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -740,8 +740,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -760,8 +760,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_zto_expanding_to_time(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2016-07-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2016-07-01T00:00:00+02:00')
 
         original = {
             'test1': {
@@ -769,8 +769,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -778,8 +778,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -787,8 +787,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -824,8 +824,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2016-07-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2016-07-01T00:00:00+02:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -844,8 +844,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_zto_expanding_from_time(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -853,8 +853,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -862,8 +862,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -871,8 +871,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -909,8 +909,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2010-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2010-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -929,8 +929,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_zto_inside_bounds(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2012-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2015-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -938,8 +938,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -947,8 +947,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -956,8 +956,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1003,8 +1003,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_zto_extending_both_ends(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2020-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2020-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -1012,8 +1012,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ2',
                         'virkning': {
-                            'from': '2013-01-01T00:00:00+00:00',
-                            'to': '2014-01-01T00:00:00+00:00',
+                            'from': '2013-01-01T00:00:00+01:00',
+                            'to': '2014-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1021,8 +1021,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1030,8 +1030,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2015-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2015-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1068,8 +1068,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2010-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2010-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1077,8 +1077,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ3',
                         'virkning': {
-                            'from': '2014-01-01T00:00:00+00:00',
-                            'to': '2020-01-01T00:00:00+00:00',
+                            'from': '2014-01-01T00:00:00+01:00',
+                            'to': '2020-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1097,8 +1097,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_zto_extending_both_ends_single_effect(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2020-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2020-01-01T00:00:00+01:00')
 
         original = {
             'test1': {
@@ -1106,8 +1106,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2012-01-01T00:00:00+00:00',
-                            'to': '2013-01-01T00:00:00+00:00',
+                            'from': '2012-01-01T00:00:00+01:00',
+                            'to': '2013-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1144,8 +1144,8 @@ class TestClass(util.TestCase):
                     {
                         'uuid': 'HEJ1',
                         'virkning': {
-                            'from': '2010-01-01T00:00:00+00:00',
-                            'to': '2020-01-01T00:00:00+00:00',
+                            'from': '2010-01-01T00:00:00+01:00',
+                            'to': '2020-01-01T00:00:00+01:00',
                             'from_included': True,
                             'to_included': False,
                         }
@@ -1164,8 +1164,8 @@ class TestClass(util.TestCase):
 
     def test_ensure_bounds_handles_unknown_fields(self):
         # Arrange
-        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+00:00')
-        new_to = mora_util.parsedatetime('2020-01-01T00:00:00+00:00')
+        new_from = mora_util.parsedatetime('2010-01-01T00:00:00+01:00')
+        new_to = mora_util.parsedatetime('2020-01-01T00:00:00+01:00')
 
         original = {
             'unknown': {

--- a/backend/tests/test_service_itsystem.py
+++ b/backend/tests/test_service_itsystem.py
@@ -27,7 +27,7 @@ class TestInvalidItSystem(util.TestCase):
                     'user_key': 'LoRA',
                     'uuid': '990255f7-44c7-4fec-9ef8-27fe73763afd',
                     'validity': {
-                        'from': '2018-03-05T08:47:00+01:00', 'to': None,
+                        'from': '2018-03-05', 'to': None,
                     },
                 },
                 {
@@ -37,7 +37,7 @@ class TestInvalidItSystem(util.TestCase):
                     'user_key': 'AD',
                     'uuid': 'a7ecd46a-9d70-4170-bde9-9bf44cf8632b',
                     'validity': {
-                        'from': '2018-03-14T08:58:00+01:00', 'to': None,
+                        'from': '2018-03-14', 'to': None,
                     },
                 },
                 {
@@ -47,7 +47,7 @@ class TestInvalidItSystem(util.TestCase):
                     'user_key': 'LoRA',
                     'uuid': '990255f7-44c7-4fec-9ef8-27fe73763afd',
                     'validity': {
-                        'from': '2018-03-19T08:57:00+01:00', 'to': None,
+                        'from': '2018-03-19', 'to': None,
                     },
                 },
                 {
@@ -57,7 +57,7 @@ class TestInvalidItSystem(util.TestCase):
                     'user_key': 'LoRA',
                     'uuid': '990255f7-44c7-4fec-9ef8-27fe73763afd',
                     'validity': {
-                        'from': '2018-03-19T09:21:00+01:00', 'to': None,
+                        'from': '2018-03-19', 'to': None,
                     },
                 },
             ],

--- a/backend/tests/test_style.py
+++ b/backend/tests/test_style.py
@@ -22,7 +22,6 @@ UPSTREAM_FILES = {
 
 # TODO: re-enable style checks for these files as needed
 SKIP_LIST = {
-    'tests/test_selenium.py',
 }
 
 SKIP_DIRS = {

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -47,12 +47,12 @@ class TestUtils(TestCase):
             '-infinity': '-infinity',
 
             '2017-07-31T22:00:00+00:00':
-            '2017-07-31T22:00:00+00:00',
+            '2017-08-01T00:00:00+02:00',
 
             # the frontend doesn't escape the 'plus' in ISO 8601 dates, so
             # we get it as a space
             '2017-07-31T22:00:00 00:00':
-            '2017-07-31T22:00:00+00:00',
+            '2017-08-01T00:00:00+02:00',
 
             datetime.date(2015, 6, 1):
             '2015-06-01T00:00:00+02:00',

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -357,8 +357,8 @@ class TestUtils(TestCase):
         )
 
     def test_get_valid_to(self):
-        ts = '2018-03-21T00:00:00+01:00'
-        dt = datetime.datetime(2018, 3, 21,
+        ts = '2018-03-21'
+        dt = datetime.datetime(2018, 3, 22,
                                tzinfo=dateutil.tz.tzoffset(None, 3600))
 
         self.assertEqual(dt, util.get_valid_to(
@@ -378,7 +378,7 @@ class TestUtils(TestCase):
                 'validity': {
                     'to': ts,
                 }
-            }
+            },
         ))
 
         self.assertEqual(
@@ -484,6 +484,15 @@ class TestUtils(TestCase):
 
         self.assertEqual(
             datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
+            util.get_valid_from({
+                'validity': {
+                    'from': '2018-03-05',
+                },
+            }),
+        )
+
+        self.assertEqual(
+            datetime.datetime(2018, 3, 6, tzinfo=util.DEFAULT_TIMEZONE),
             util.get_valid_to({
                 'validity': {
                     'to': '2018-03-05',
@@ -502,7 +511,16 @@ class TestUtils(TestCase):
         )
 
         self.assertEqual(
-            datetime.datetime(2018, 3, 5, tzinfo=util.DEFAULT_TIMEZONE),
+            datetime.datetime(2018, 3, 6, tzinfo=util.DEFAULT_TIMEZONE),
+            util.get_valid_to({}, {
+                'validity': {
+                    'to': '2018-03-05',
+                },
+            }),
+        )
+
+        self.assertEqual(
+            datetime.datetime(2018, 3, 6, tzinfo=util.DEFAULT_TIMEZONE),
             util.get_valid_to({}, {
                 'validity': {
                     'to': '2018-03-05',
@@ -516,7 +534,7 @@ class TestUtils(TestCase):
             util.get_validities({
                 'validity': {
                     'from': '2018-03-05',
-                    'to': '2018-04-05',
+                    'to': '2018-04-04',
                 },
             }),
         )

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -91,46 +91,6 @@ class TestUtils(TestCase):
         # test fallback
         self.assertEqual(util.parsedatetime('blyf', 'flaf'), 'flaf')
 
-    def test_to_frontend_time(self):
-        self.assertEqual(util.to_frontend_time(self.today), '01-06-2015')
-
-        self.assertEqual(util.to_frontend_time('2017-12-31 00:00:00+01'),
-                         '31-12-2017')
-        self.assertEqual(util.to_frontend_time('infinity'), 'infinity')
-        self.assertEqual(util.to_frontend_time('-infinity'), '-infinity')
-
-        self.assertEqual(
-            util.to_frontend_time('1980-07-01 00:00:00+02'),
-            '01-07-1980',
-        )
-
-        self.assertEqual(
-            util.to_frontend_time('1980-01-01 00:00:00+01'),
-            '01-01-1980',
-        )
-
-        self.assertEqual(
-            util.to_frontend_time('1980-07-01 02:00:00+02'),
-            '1980-07-01T02:00:00+02:00',
-        )
-
-        self.assertEqual('01-06-2015',
-                         util.to_frontend_time(datetime.date.today()))
-        self.assertEqual('01-06-2015',
-                         util.to_frontend_time(self.today))
-        self.assertEqual('2015-06-01T01:10:00+02:00',
-                         util.to_frontend_time(self.now))
-        self.assertEqual('01-01-2015',
-                         util.to_frontend_time(datetime.date(2015, 1, 1)))
-        self.assertEqual('01-06-2015',
-                         util.to_frontend_time(datetime.date(2015, 6, 1)))
-
-        self.assertEqual('-infinity',
-                         util.to_frontend_time('-infinity'))
-
-        self.assertEqual('infinity',
-                         util.to_frontend_time('infinity'))
-
     def test_splitlist(self):
         self.assertEqual(
             list(util.splitlist([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3)),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinxcontrib.httpdomain',
     'sphinxcontrib.autohttp.flask',
     'sphinxcontrib.autohttp.flaskqref',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.8",
     "rimraf": "^2.6.0",
-    "selenium-server": "^3.0.1",
     "semver": "^5.3.0",
     "shelljs": "^0.7.6",
     "sinon": "^4.0.0",

--- a/frontend/src/employee/MoEmployeeWorkflows/MoEmployeeTerminate.vue
+++ b/frontend/src/employee/MoEmployeeWorkflows/MoEmployeeTerminate.vue
@@ -20,7 +20,7 @@
         <mo-date-picker 
           class="from-date" 
           :label="$t('input_fields.end_date')" 
-          v-model="terminate.validity.from" 
+          v-model="terminate.validity.to" 
           required
         />
       </div>
@@ -68,7 +68,7 @@
 
     computed: {
       isDisabled () {
-        return !this.employee.uuid || !this.terminate.validity.from
+        return !this.employee.uuid || !this.terminate.validity.to
       },
 
       formValid () {

--- a/frontend/src/organisation/MoOrganisationUnitWorkflows/MoOrganisationUnitTerminate.vue
+++ b/frontend/src/organisation/MoOrganisationUnitWorkflows/MoOrganisationUnitTerminate.vue
@@ -21,7 +21,7 @@
         <mo-date-picker
           :label="$t('input_fields.end_date')"
           :valid-dates="validDates"
-          v-model="terminate.validity.from"
+          v-model="terminate.validity.to"
           required/>
       </div>
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5956,10 +5956,6 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
-selenium-server@^3.0.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/selenium-server/-/selenium-server-3.8.1.tgz#61c53afd8614ef4c61bc0823cdd9a6fd0f3f21d7"
-
 selfsigned@^1.9.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.1.tgz#bf8cb7b83256c4551e31347c6311778db99eec52"


### PR DESCRIPTION
We now use ISO 8601 dates in the API, rather than dates with time.
When reading from LoRA, we simply disregard any date. When validating
requests, anything other than midnight CE[S]T causes a hard error.

This works rather well in practice, although it _may_ lead to issues
should other clients of LoRA write an address or IT system with a
validity changeover not at midnight. In this case, we should be able
to read the data, but not alter it.

<!-- Insert a link for relevant Redmine ticket(s) here -->

https://redmine.magenta-aps.dk/issues/23559

- [x] Have you updated the documentation?
- [x] Have you performed a smoke test of the application?
- [x] Have you written tests for your changes?
- [x] Have you updated the release notes?

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->