### PR TITLE
docs: use sphinx from our venv by default

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,10 @@
 # You can set these variables from the command line.
 PYTHON = python3
 SPHINXOPTS    =
+SPHINXBUILD   = ../backend/venv/bin/sphinx-build
+ifeq ($(realpath $(SPHINXBUILD)),)
 SPHINXBUILD   = $(PYTHON) -msphinx
+endif
 SPHINXPROJ    = MORa
 SOURCEDIR     = .
 BUILDDIR      = out


### PR DESCRIPTION
Trivial change that makes `make -C docs` more likely to work in a development setup.

<!-- Insert a link for relevant Redmine ticket(s) here -->

- [x] ~Have you updated the documentation?~
- [x] ~Have you performed a smoke test of the application?~
- [x] ~Have you written tests for your changes?~
- [x] ~Have you updated the release notes?~

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
