### PR TITLE
#24386 TestCafé results

### DIFF
--- a/backend/mora/app.py
+++ b/backend/mora/app.py
@@ -8,6 +8,7 @@
 #
 
 import os
+import typing
 
 import flask
 import werkzeug
@@ -24,45 +25,60 @@ basedir = os.path.dirname(__file__)
 templatedir = os.path.join(basedir, 'templates')
 distdir = os.path.join(basedir, '..', '..', 'frontend', 'dist')
 
-app = flask.Flask(__name__, root_path=distdir, template_folder=templatedir)
-app.cli = cli.group
 
-app.config.from_object(settings)
+def create_app(overrides: typing.Dict[str, typing.Any] = None):
+    '''Create and return a Flask app instance for MORA.
 
-flask_session.Session(app)
+    :param dict overrides: Settings to override prior to extension
+                           instantiation.
 
-app.register_blueprint(base.blueprint)
-app.register_blueprint(sso.blueprint)
+    '''
+    app = flask.Flask(__name__, root_path=distdir, template_folder=templatedir)
+    app.cli = cli.group
 
-for blueprint in service.blueprints:
-    app.register_blueprint(blueprint)
+    app.config.from_object(settings)
+
+    if overrides is not None:
+        app.config.update(overrides)
+
+    flask_session.Session(app)
+
+    app.register_blueprint(base.blueprint)
+    app.register_blueprint(sso.blueprint)
+
+    for blueprint in service.blueprints:
+        app.register_blueprint(blueprint)
+
+    @app.errorhandler(Exception)
+    def handle_invalid_usage(error):
+        """
+        Handles errors in case an exception is raised.
+
+        :param error: The error raised.
+        :return: JSON describing the problem and the apropriate status code.
+        """
+
+        if not isinstance(error, werkzeug.routing.RoutingException):
+            util.log_exception('unhandled exception')
+
+        if not isinstance(error, werkzeug.exceptions.HTTPException):
+            error = exceptions.HTTPException(
+                description=str(error),
+            )
+
+        return error.get_response(flask.request.environ)
+
+    @app.route('/')
+    @app.route('/<path:path>')
+    def root(path=''):
+        if path.split('/', 1)[0] == 'service':
+            raise exceptions.HTTPException(
+                exceptions.ErrorCodes.E_NO_SUCH_ENDPOINT)
+
+        return flask.send_file('index.html')
+
+    return app
 
 
-@app.errorhandler(Exception)
-def handle_invalid_usage(error):
-    """
-    Handles errors in case an exception is raised.
-
-    :param error: The error raised.
-    :return: JSON describing the problem and the apropriate status code.
-    """
-
-    if not isinstance(error, werkzeug.routing.RoutingException):
-        util.log_exception('unhandled exception')
-
-    if not isinstance(error, werkzeug.exceptions.HTTPException):
-        error = exceptions.HTTPException(
-            description=str(error),
-        )
-
-    return error.get_response(flask.request.environ)
-
-
-@app.route('/')
-@app.route('/<path:path>')
-def root(path=''):
-    if path.split('/', 1)[0] == 'service':
-        raise exceptions.HTTPException(
-            exceptions.ErrorCodes.E_NO_SUCH_ENDPOINT)
-
-    return flask.send_file('index.html')
+# create a default instance for backwards compatibility
+app = create_app()

--- a/backend/tests/test_sso.py
+++ b/backend/tests/test_sso.py
@@ -10,24 +10,22 @@ import os
 from urllib.parse import urlparse, parse_qs, urlencode
 
 import freezegun
-from flask_testing import TestCase
 from mock import patch
 from onelogin.saml2.utils import OneLogin_Saml2_Utils as saml_utils
 
-from mora.app import app
+from . import util
 
 TESTS_DIR = os.path.dirname(__file__)
 
 
-class TestSSO(TestCase):
+class TestSSO(util.TestCase):
 
     def create_app(self):
-        app.config['TESTING'] = True
-        app.config['SERVER_NAME'] = "127.0.0.1:5000"
-
-        app.config['AUTH'] = True
-        app.config['SAML_IDP_METADATA_FILE'] = TESTS_DIR + '/sso/idp.xml'
-        return app
+        return super().create_app({
+            'AUTH': True,
+            'SAML_IDP_METADATA_FILE': TESTS_DIR + '/sso/idp.xml',
+            'SERVER_NAME': "127.0.0.1:5000",
+        })
 
     def get_sso_response(self):
         with open(TESTS_DIR + '/sso/sso_response.xml', 'rb') as sso_response:

--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -11,7 +11,9 @@ import json
 import os
 import pprint
 import re
+import shutil
 import sys
+import tempfile
 import threading
 from unittest.mock import patch
 
@@ -312,11 +314,17 @@ class TestCaseMixin(object):
     maxDiff = None
 
     def create_app(self, overrides=None):
+        session_dir = tempfile.mkdtemp(prefix='session', dir=BUILD_DIR)
+
+        self.addCleanup(shutil.rmtree, session_dir)
+
         return app.create_app({
             'DEBUG': False,
             'TESTING': True,
             'LIVESERVER_PORT': 0,
             'PRESERVE_CONTEXT_ON_EXCEPTION': False,
+            'SESSION_TYPE': 'filesystem',
+            'SESSION_FILE_DIR': session_dir,
             **(overrides or {})
         })
 

--- a/backend/tests/util.py
+++ b/backend/tests/util.py
@@ -15,6 +15,7 @@ import sys
 import threading
 from unittest.mock import patch
 
+import flask
 import flask_testing
 import requests
 import requests_mock
@@ -245,12 +246,12 @@ def override_config(**overrides):
     originals = {}
 
     for k, v in overrides.items():
-        originals[k] = app.app.config[k]
-        app.app.config[k] = v
+        originals[k] = flask.current_app.config[k]
+        flask.current_app.config[k] = v
 
     yield
 
-    app.app.config.update(overrides)
+    flask.current_app.config.update(overrides)
 
 
 class mock(requests_mock.Mocker):
@@ -310,13 +311,14 @@ class TestCaseMixin(object):
 
     maxDiff = None
 
-    def create_app(self):
-        app.app.config['DEBUG'] = False
-        app.app.config['TESTING'] = True
-        app.app.config['LIVESERVER_PORT'] = 0
-        app.app.config['PRESERVE_CONTEXT_ON_EXCEPTION'] = False
-
-        return app.app
+    def create_app(self, overrides=None):
+        return app.create_app({
+            'DEBUG': False,
+            'TESTING': True,
+            'LIVESERVER_PORT': 0,
+            'PRESERVE_CONTEXT_ON_EXCEPTION': False,
+            **(overrides or {})
+        })
 
     @property
     def lora_url(self):

--- a/docs/vuedoc/MoAddressPicker.md
+++ b/docs/vuedoc/MoAddressPicker.md
@@ -56,6 +56,10 @@ A address picker component.
 
    **dependencies:** `addresses` 
 
+- `orderedListOptions` 
+
+   **dependencies:** `addresses` 
+
 
 ## events 
 

--- a/docs/vuedoc/MoEmployeePicker.md
+++ b/docs/vuedoc/MoEmployeePicker.md
@@ -32,6 +32,13 @@ A employee picker component.
 
 **initial value:** `'MoSearchBarTemplate'` 
 
+## computed properties 
+
+- `orderedListOptions` 
+
+   **dependencies:** `items` 
+
+
 ## events 
 
 - `input` 

--- a/docs/vuedoc/MoEngagementPicker.md
+++ b/docs/vuedoc/MoEngagementPicker.md
@@ -57,6 +57,10 @@ A engagement picker component.
 
    **dependencies:** `employee`, `employee` 
 
+- `orderedListOptions` 
+
+   **dependencies:** `engagements` 
+
 
 ## events 
 

--- a/docs/vuedoc/MoFacetPicker.md
+++ b/docs/vuedoc/MoFacetPicker.md
@@ -45,6 +45,10 @@ A facet picker component.
 
    **dependencies:** `preselectedUserKey` 
 
+- `orderedListOptions` 
+
+   **dependencies:** `facets` 
+
 
 ## methods 
 

--- a/docs/vuedoc/MoItSystemPicker.md
+++ b/docs/vuedoc/MoItSystemPicker.md
@@ -33,6 +33,10 @@ A it system component.
 
    **dependencies:** `_uid` 
 
+- `orderedListOptions` 
+
+   **dependencies:** `itSystems` 
+
 
 ## events 
 

--- a/docs/vuedoc/MoOrganisationPicker.md
+++ b/docs/vuedoc/MoOrganisationPicker.md
@@ -33,6 +33,13 @@ A organisation picker component.
 
 **initial value:** `[object Object]` 
 
+## computed properties 
+
+- `orderedListOptions` 
+
+   **dependencies:** `orgs` 
+
+
 ## methods 
 
 - `getAll()` 

--- a/docs/vuedoc/MoSearchBar.md
+++ b/docs/vuedoc/MoSearchBar.md
@@ -33,6 +33,13 @@ A searchbar component.
 
 **initial value:** `[object Object]` 
 
+## computed properties 
+
+- `orderedListOptions` 
+
+   **dependencies:** `items` 
+
+
 ## methods 
 
 - `getLabel(item)` 

--- a/frontend/e2e-tests/MoEmployeeCreate.js
+++ b/frontend/e2e-tests/MoEmployeeCreate.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -163,5 +164,11 @@ test('Workflow: create employee', async t => {
     // Submit button
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#employeeCreate').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Medarbejderen med UUID [-0-9a-f]* er blevet oprettet/
+    )
 })

--- a/frontend/e2e-tests/MoEmployeeLeave.js
+++ b/frontend/e2e-tests/MoEmployeeLeave.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -44,5 +45,11 @@ test('Workflow: leave employee', async t => {
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#employeeLeave').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Medarbejderen med UUID [-0-9a-f]* har fået tildelt orlov/
+    )
 })

--- a/frontend/e2e-tests/MoEmployeeMove.js
+++ b/frontend/e2e-tests/MoEmployeeMove.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -54,5 +55,17 @@ test('Workflow: move employee', async t => {
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#employeeTerminate').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Medarbejderen med UUID [-0-9a-f]* er blevet redigeret/
+    )
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-2).innerText)
+    .match(
+      /Medarbejderen med UUID [-0-9a-f]* er blevet flyttet/
+    )
 })

--- a/frontend/e2e-tests/MoEmployeeMoveMany.js
+++ b/frontend/e2e-tests/MoEmployeeMoveMany.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -34,14 +35,22 @@ test('Workflow: moveMany employee', async t => {
     .expect(fromInput.value).eql(today.format('DD-MM-YYYY'))
 
     .click(parentFromInput)
-    .click(dialog.find('.from-unit li .item .link-color'))
+    .click(dialog.find('.from-unit .item .link-color')
+           .withText('Ballerup Kommune'))
 
     .click(parentToInput)
-    .click(dialog.find('.to-unit li .item .link-color'))
+    .click(dialog.find('.to-unit .item .link-color')
+           .withText('Ballerup Bibliotek'))
 
     .click(checkboxInput)
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#orgUnitRename').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Medarbejderen med UUID [-0-9a-f]* er blevet redigeret/
+    )
 })

--- a/frontend/e2e-tests/MoEmployeeTerminate.js
+++ b/frontend/e2e-tests/MoEmployeeTerminate.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -38,5 +39,11 @@ test('Workflow: terminate employee', async t => {
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#employeeTerminate').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Medarbejderen med UUID [-0-9a-f]* er afsluttet/
+    )
 })

--- a/frontend/e2e-tests/MoOrganisationUnitCreate.js
+++ b/frontend/e2e-tests/MoOrganisationUnitCreate.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -83,7 +84,12 @@ test('Workflow: create unit', async t => {
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#orgUnitCreate').exists).notOk()
+    .expect(dialog.exists).notOk()
 
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Organisationsenheden med UUID [-0-9a-f]* er blevet oprettet/
+    )
   // TODO: verify that the unit was actually created, somehow?
 })

--- a/frontend/e2e-tests/MoOrganisationUnitMove.js
+++ b/frontend/e2e-tests/MoOrganisationUnitMove.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -26,10 +27,12 @@ test('Workflow: move unit', async t => {
     .expect(dialog.exists).ok('Opened dialog')
 
     .click(unitInput)
-    .click(dialog.find('li .item .link-color'))
+    .click(dialog.find('li .item .link-color')
+           .withText('Ballerup Familiehus'))
 
     .click(parentInput)
-    .click(dialog.find('.parentUnit li .item .link-color'))
+    .click(dialog.find('.parentUnit li .item .link-color')
+           .withText('Ballerup Bibliotek'))
 
     .click(fromInput)
     .hover(dialog.find('.vdp-datepicker .day:not(.blank)')
@@ -40,5 +43,11 @@ test('Workflow: move unit', async t => {
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#orgUnitCreate').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Organisationsenheden med UUID [-0-9a-f]* er blevet flyttet/
+    )
 })

--- a/frontend/e2e-tests/MoOrganisationUnitRename.js
+++ b/frontend/e2e-tests/MoOrganisationUnitRename.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -37,5 +38,11 @@ test('Workflow: rename unit', async t => {
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#orgUnitRename').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Organisationsenheden med UUID [-0-9a-f]* er blevet omdøbt/
+    )
 })

--- a/frontend/e2e-tests/MoOrganisationUnitTerminate.js
+++ b/frontend/e2e-tests/MoOrganisationUnitTerminate.js
@@ -1,5 +1,6 @@
 import { Selector } from 'testcafe'
 import { baseURL } from './support'
+import VueSelector from 'testcafe-vue-selectors'
 
 let moment = require('moment')
 
@@ -34,5 +35,11 @@ test('Workflow: terminate employee', async t => {
 
     .click(dialog.find('.btn-primary'))
 
-    .expect(Selector('#orgUnitTerminate').exists).notOk()
+    .expect(dialog.exists).notOk()
+
+    .expect(VueSelector('MoLog MoWorklog')
+            .find('.alert').nth(-1).innerText)
+    .match(
+      /Organisationsenheden med UUID [-0-9a-f]* er blevet afsluttet/
+    )
 })


### PR DESCRIPTION
This PR changes the TestCafé tests so that they validate that the corresponding actions actually succeed, by checking the log. It turns out that some of the operations _didn't_ do so, due to changes made by earlier tests. To fix this, I changed our test runner to reset the DB between each test — this is significantly slower, but more thorough and reliable.

I was motivated for this by a change that _ought_ to break the tests — but didn't.

<!-- Insert a link for relevant Redmine ticket(s) here -->

https://redmine.magenta-aps.dk/issues/24386

---

- [ ] ~Have you updated the documentation?~
- [ ] ~Have you performed a smoke test of the application?~
- [x] Have you written tests for your changes?
- [ ] ~Have you updated the release notes?~

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->
