### PR TITLE
hotfix: add a check for vuedoc.md to unbreak to mox testsuite

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,18 @@
+Version 0.10.1-post1, 2018-10-12
+================================
+
+Bug fixes
+---------
+
+* A missing check for Node packages broke the `mox
+  <http://github.com/magenta-aps/mox/>` test suite.
+
+Known bugs
+----------
+
+* #24134: Sorting doesn't work after performing an update.
+
+
 Version 0.10.1, 2018-10-08
 ==========================
 

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -17,9 +17,15 @@ import unittest
 from . import util
 
 
+VUEDOC_CMD = os.path.join(util.FRONTEND_DIR,
+                          'node_modules', '.bin', 'vuedoc.md')
+
+
 class Tests(unittest.TestCase):
     maxDiff = None
 
+    @unittest.skipUnless(os.path.exists(VUEDOC_CMD),
+                         'vuedoc.md unavailable!')
     def test_is_vuedoc_uptodate(self):
         '''Check whether the VueDoc-generated files are up-to-date.'''
 
@@ -36,8 +42,7 @@ class Tests(unittest.TestCase):
 
         subprocess.check_call(
             [
-                os.path.join(util.FRONTEND_DIR,
-                             'node_modules', '.bin', 'vuedoc.md'),
+                VUEDOC_CMD,
                 '--output', tempdir,
                 *sources,
             ],


### PR DESCRIPTION
https://lorajenkins.magenta.dk/job/LoRa/job/PR-73-head/1/testReport/junit/tests.test_docs/Tests/test_is_vuedoc_uptodate/

<!-- Insert a link for relevant Redmine ticket(s) here -->

- [x] Have you updated the documentation?
- [ ] ~Have you performed a smoke test of the application?~
- [ ] ~Have you written tests for your changes?~
- [x] Have you updated the release notes?

<!--
  If you've left boxes unchecked, remember to explain why; use ~~ to
  add a strike through to any that don't apply
-->